### PR TITLE
Fixed the module for pixhost

### DIFF
--- a/gallery_dl/extractor/imagehosts.py
+++ b/gallery_dl/extractor/imagehosts.py
@@ -312,8 +312,8 @@ class PixhostImageExtractor(ImagehostImageExtractor):
     cookies = {"pixhostads": "1", "pixhosttest": "1"}
 
     def get_info(self, page):
-        url     , pos = text.extract(page, "src: '", "'")
-        filename, pos = text.extract(page, "title: '", "'", pos)
+        url     , pos = text.extract(page, "class=\"image-img\" src=\"", "\"")
+        filename, pos = text.extract(page, "alt=\"", "\"", pos)
         return url, filename
 
 


### PR DESCRIPTION
Hello,

gallery-dl doesn't work correctly from some images on pixhost that is part of an album.
The original code will fetch the first image of the album instead of the image shown for that URL.
Try this URL for a test case:
http://pixhost.org/show/1304/36787835_img_20170114_110314.jpg

This patch fixes the above described problem.

Thank you.