### PR TITLE
[pixiv] support tag for user downloads

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -36,7 +36,10 @@ class PixivUserExtractor(Extractor):
     def __init__(self, match):
         Extractor.__init__(self)
         self.artist_id = match.group(1)
-        self.tag = match.group(2)
+        if (len(match.groups) > 2):
+            self.tag = match.group(2)
+        else:
+            self.tag = None
         self.api = PixivAPI(self)
         self.api_call = self.api.user_works
         self.load_ugoira = self.config("ugoira", True)

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -36,7 +36,7 @@ class PixivUserExtractor(Extractor):
     def __init__(self, match):
         Extractor.__init__(self)
         self.artist_id = match.group(1)
-        if (len(match.groups) > 2):
+        if (len(match.groups()) > 2):
             self.tag = match.group(2)
         else:
             self.tag = None


### PR DESCRIPTION
Pixiv user links can include a tag (https://www.pixiv.net/member_illust.php?id={user}&tag={tag}), which means to only show images with that tag. This PR adds support for that to the extractor.