### PR TITLE
Update imgur.py to include 'title' of single image

### DIFF
--- a/gallery_dl/extractor/imgur.py
+++ b/gallery_dl/extractor/imgur.py
@@ -52,7 +52,7 @@ class ImgurExtractor(Extractor):
 class ImgurImageExtractor(ImgurExtractor):
     """Extractor for individual images from imgur.com"""
     subcategory = "image"
-    filename_fmt = "{category}_{hash}.{extension}"
+    filename_fmt = "{category}_{hash}_{title}.{extension}"
     pattern = [(r"(?:https?://)?(?:m\.|www\.)?imgur\.com/"
                 r"(?:gallery/)?((?!gallery)[^/?&#]{7})/?"),
                (r"(?:https?://)?i\.imgur\.com/([^/?&#.]{5,7})\.")]


### PR DESCRIPTION
Add {title} keyword..
Images on Imgur don't necessarily have a title, but I think most of them do, and since this should not break anything else..

Not sure about the right order. Proposed is:
`"{category}_{hash}_{title}.{extension}"` 

Alternatively:
`"{category}_{title}_{hash}.{extension}"`

This would have the benefit of alphabetical sorting of images with similar titles, they are likely to be related, and now they would be in a proper order, at least to some extent.

Of course. feel free to modify, change, reject. etc..

 