### PR TITLE
Add parameter to DownoadJob constructor to specify which output class I want to use

### DIFF
--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -135,12 +135,12 @@ class Job():
 class DownloadJob(Job):
     """Download images into appropriate directory/filename locations"""
 
-    def __init__(self, url, parent=None):
+    def __init__(self, url, parent=None, output_object=output.select()):
         Job.__init__(self, url, parent)
         self.pathfmt = None
         self.sleep = None
         self.downloaders = {}
-        self.out = output.select()
+        self.out = output_object
 
     def handle_url(self, url, keywords):
         """Download the resource specified in 'url'"""

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -9,6 +9,8 @@
 
 import unittest
 import gallery_dl.util as util
+import gallery_dl.job as job
+import gallery_dl.output as output
 import gallery_dl.exception as exception
 import sys
 
@@ -244,6 +246,13 @@ class TestOther(unittest.TestCase):
         self.assertEqual(util.safe_int("zzz", "default"), "default")
         self.assertEqual(util.safe_int("", "default"), "default")
         self.assertEqual(util.safe_int(None, "default"), "default")
+
+
+class TestDownloadJob(unittest.TestCase):
+    def test_out_attribute(self):
+        test_url = 'https://imgur.com/gallery/JK12s'
+        dl_job = job.DownloadJob(test_url, output_object=output.NullOutput())
+        self.assertTrue(isinstance(dl_job.out, output.NullOutput))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm using gallery-dl as an API, and it's easier to do this than to mess with the config file to specify the output object used for the color, pipe, terminal, or null printing options.

Not sure how you want to organize a unit test for this along with your existing ones, but I threw in a very basic check.