### PR TITLE
Fix UnicodeDecodeError during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ except ImportError:
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    import codecs
+    return codecs.open(os.path.join(os.path.dirname(__file__), fname), 'r', 'utf-8').read()
 
 
 # get version without importing the package

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ except ImportError:
 
 
 def read(fname):
-    import codecs
-    return codecs.open(os.path.join(os.path.dirname(__file__), fname), 'r', 'utf-8').read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 
 # get version without importing the package


### PR DESCRIPTION
I encountered the following error when installing `gallery-dl` using Python 3.5.2 on Ubuntu 16.04 LTS.

Installation command
```bash
python3 setup.py install
```

Encountered error
```text
Traceback (most recent call last):
  File "setup.py", line 21, in <module>
    exec(read("gallery_dl/version.py"))
  File "setup.py", line 17, in read
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 53: ordinal not in range(128)
```

In the file `gallery_dl/version.py`, there is a non-ascii character in name `Mike Fährmann`. 
So `setup.py` failed to read the version with default encoding ascii and raised the exception.

Original `read()` in `setup.py`
```python
def read(fname):
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
```

I revised `read()` into
```python
def read(fname):
    import codecs
    return codecs.open(os.path.join(os.path.dirname(__file__), fname), 'r', 'utf-8').read()
```

And `gallery-dl` was installed successfully.
