### PR TITLE
[tumblr] update regex for video subdomain

### DIFF
--- a/gallery_dl/extractor/tumblr.py
+++ b/gallery_dl/extractor/tumblr.py
@@ -25,7 +25,7 @@ def _original_inline_image(url):
 
 def _original_video(url):
     return re.sub(
-        (r"https?://(vt+(?:\.media)?\.tumblr\.com"
+        (r"https?://((?:vt|vtt|ve)(?:\.media)?\.tumblr\.com"
          r"/tumblr_[^_]+)_\d+\.([0-9a-z]+)"),
         r"https://\1.\2", url
     )


### PR DESCRIPTION
There seems to be another sub-domain for videos, apparently..
Not just
`vt(.media).tumblr`
`vtt(media).tumblr`
But also
`ve(.media).tumblr`

Two examples pulled via `\posts\` endpoint on Web API Console:
```
"video_url": "https://ve.media.tumblr.com/tumblr_n1zsb87J961ts7u0r.mp4",
"video_url": "https://ve.media.tumblr.com/tumblr_n1zsdjVyDf1ts7u0r.mp4",
```
Note that both return `403`, that old issue with videos on Tumblr etc. pp.
I think I've only seen one at `ve.media.tumblr.com` so far, but that was working.
So this exists 😄 

Please comment/change/edit as you see fit.

@mikf I've only tested these changes with the regex101.com tool (Python mode) and not via local Python interpreter or something, but I think this should work.
Also, a question just for understanding:
Do I get this right, that this regex was only intended to match URLs returned from the API that contain something like `_540`, `_720` etc.? Because the regex seems not to match at all otherwise. But I think this is intentional, right (The URL does not need to be changed/"improved" here)?

Edit:

I mean, just like these two example URLs returned from the Tumblr API above.
The regex does not match at all, and it doesn't need to.

Only for URLs like this (fictional example):
```
"video_url": "https://ve.media.tumblr.com/tumblr_n1zsb87J961ts7u0r_540.mp4",
"video_url": "https://ve.media.tumblr.com/tumblr_n1zsdjVyDf1ts7u0r_720.mp4",
```

But in this case it should work as expected 😄 