### PR TITLE
Implement snap packaging, snaps are universal linux packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,12 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Snap packaging specific
+/snap/.snapcraft/
+/parts/
+/stage/
+/prime/
+
+/*.snap
+/*_source.tar.bz2

--- a/snap/local/launchers/gallery-dl-launch
+++ b/snap/local/launchers/gallery-dl-launch
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# This is the maintainence launcher for the snap, make necessary runtime environment changes to make the snap work here.  You may also insert security confinement/deprecation/obsoletion notice of the snap here.
+
+set \
+	-o errexit \
+	-o errtrace \
+	-o nounset \
+	-o pipefail
+
+if ! test -v SNAP_ARCH_TRIPLET; then
+	printf 'Error: SNAP_ARCH_TRIPLET not set, this launcher requires workaround-snap-arch-triplet-launch launcher to work.\n' >&2
+	exit 1
+fi
+
+# Satisfy FFmpeg's usr/lib/ARCH/pulseaudio/libpulsecommon-11.1.so dependency
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}":"$SNAP"/usr/lib/"${SNAP_ARCH_TRIPLET}"/pulseaudio
+
+# Use user's real home directory for canonical configuration path access
+# FIXME: Waiting for Snap Store assertion
+declare REALHOME="$(
+	getent passwd "${USER}" \
+		| cut --delimiter=: --fields=6
+)"
+
+if ! test -f "${SNAP_USER_COMMON}"/.config/gallery-dl/config.json \
+	&& ! test -f "${SNAP_USER_COMMON}"/.gallery-dl.conf; then
+	declare userwide_config_file
+
+	for possible_config_file in \
+		"${REALHOME}"/.config/gallery-dl/config.json \
+		"${REALHOME}"/.gallery-dl.conf; do
+		if test -f "${possible_config_file}"; then
+			userwide_config_file="${possible_config_file}"
+		fi
+	done
+
+	if test -v userwide_config_file; then
+		printf -- \
+			'gallery-dl-launch: It appears that you have a gallery-dl configuration in your home directory, currently the snap distribution of gallery-dl cannot access it until you create a link via running the following command in the terminal:\n\n'
+		printf -- \
+			'gallery-dl-launch:     ln %s %s\n\n' \
+			"${userwide_config_file}" \
+			"~/snap/$SNAP_NAME/common/.gallery-dl.conf"
+	fi
+fi
+
+#HOME="${REALHOME}"
+
+# Finally run the next part of the command chain
+exec "${@}"

--- a/snap/local/launchers/workaround-snap-arch-triplet-launch
+++ b/snap/local/launchers/workaround-snap-arch-triplet-launch
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# This launcher sets the Debian-specific multiarch tuples as the SNAP_ARCH_TRIPLET environmental variable for other launchers' ease
+
+set \
+	-o errexit \
+	-o errtrace \
+	-o nounset \
+	-o pipefail
+
+if ! test -v SNAP_ARCH; then
+	printf -- \
+		'%s: Error: This launcher requires SNAP_ARCH environmental variable to be set and exported.\n' \
+		"$(basename "${BASH_SOURCE[0]}")"
+	exit 1
+fi
+
+declare \
+	SNAP_ARCH_TRIPLET
+
+# Refer:
+#
+# * Environmental variables - doc - snapcraft.io
+#   https://forum.snapcraft.io/t/environmental-variables/7983
+# * Multiarch/Tuples - Debian Wiki
+#   https://wiki.debian.org/Multiarch/Tuples
+#   NOTE: Only consider Linux archs with the `released` status in Debian for now
+case "${SNAP_ARCH}" in
+	# These are the special cases
+	amd64)
+		SNAP_ARCH_TRIPLET=x86_64-linux-gnu
+	;;
+	armel)
+		SNAP_ARCH_TRIPLET=arm-linux-gnueabi
+	;;
+	armhf)
+		SNAP_ARCH_TRIPLET=arm-linux-gnueabihf
+	;;
+	arm64)
+		SNAP_ARCH_TRIPLET=aarch64-linux-gnu
+	;;
+	ppc64el)
+		SNAP_ARCH_TRIPLET=powerpc64le-linux-gnu
+	;;
+	# Consider rest of them not exceptions
+	s390x \
+	|*)
+		SNAP_ARCH_TRIPLET="${SNAP_ARCH}"-linux-gnu
+	;;
+esac
+
+export \
+	SNAP_ARCH_TRIPLET
+
+# Finally run the launching command
+exec "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,92 @@
+%YAML 1.1
+---
+# Snapcraft Recipe for gallery-dl
+# ------------------------------
+# This file is in the YAML data serialization format:
+# http://yaml.org
+# For the spec. of writing this file refer the following documentation:
+# * The snapcraft format
+#   https://docs.snapcraft.io/the-snapcraft-format/8337
+# * Snap Documentation
+#   https://docs.snapcraft.io
+# * Topics under the doc category in the Snapcraft Forum
+#   https://forum.snapcraft.io/c/doc
+# For support refer to the snapcraft section in the Snapcraft Forum:
+# https://forum.snapcraft.io/c/snapcraft
+name: gallery-dl
+license: GPL-2.0
+base: core18
+summary: Download image-galleries and -collections from several image hosting sites
+description: |
+  `gallery-dl` is a command-line program to download image-galleries and -collections from several image hosting sites (see [Supported Sites](https://github.com/mikf/gallery-dl/blob/master/docs/supportedsites.rst)). It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
+
+version: determined-by-version-script
+version-script: git describe --always --dirty --tags | sed 's/^v//'
+
+confinement: strict
+grade: stable
+
+plugs:
+  # For `xdg-open` command access for opening OAuth authentication webpages
+  desktop:
+
+  # Storage access
+  home:
+  removable-media: # Non-A/C
+
+  # Network access
+  network:
+
+  # For network service for recieving OAuth callback tokens
+  network-bind:
+
+  # Configuration access
+  # FIXME: Waiting for the Snap Store autoconnection assertion
+  # https://forum.snapcraft.io/t/interface-auto-connection-request-for-the-gallery-dl-snap/10092
+  #personal-files:
+    #read:
+    #- $HOME/.config/gallery-dl
+    #- $HOME/.gallery-dl.conf
+  #system-files:
+    #read:
+    #- /etc/gallery-dl.conf
+
+parts:
+  # Launcher programs to fix problems at runtime
+  launchers:
+    source: snap/local/launchers
+    plugin: dump
+    organize:
+      '*': bin/
+
+  gallery-dl:
+    source: .
+    plugin: python
+
+  ffmpeg:
+    plugin: nil
+    stage-packages:
+    - ffmpeg
+    - libavcodec57
+    - libavdevice57
+    - libavfilter6
+    - libavformat57
+    - libavresample3
+    - libavutil55
+    - libpostproc54
+    - libpulse0
+    - libslang2
+    - libswresample2
+    - libswscale4
+
+apps:
+  gallery-dl:
+    adapter: full
+    command-chain:
+    - bin/workaround-snap-arch-triplet-launch
+    - bin/gallery-dl-launch
+    command: bin/gallery-dl
+    environment:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+      HOME: $SNAP_USER_COMMON


### PR DESCRIPTION
This patch implements the necessary details to package gallery-dl as a snap that can be run on a broad range of supporting GNU/Linux distributions[1].

[1] https://snapcraft.io/

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>