### PR TITLE
Implement selective pulling for building tagged release snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,9 +20,7 @@ summary: Download image-galleries and -collections from several image hosting si
 description: |
   `gallery-dl` is a command-line program to download image-galleries and -collections from several image hosting sites (see [Supported Sites](https://github.com/mikf/gallery-dl/blob/master/docs/supportedsites.rst)). It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
 
-version: determined-by-version-script
-version-script: git describe --always --dirty --tags | sed 's/^v//'
-
+adopt-info: gallery-dl
 confinement: strict
 grade: stable
 
@@ -59,8 +57,19 @@ parts:
     organize:
       '*': bin/
 
+  selective-pull:
+    plugin: nil
+    build-packages:
+    - git
+    stage-snaps:
+    - selective-pull
+
   gallery-dl:
+    after:
+    - selective-pull
+
     source: .
+    override-pull: $SNAPCRAFT_STAGE/scriptlets/selective-pull
     plugin: python
 
   ffmpeg:


### PR DESCRIPTION
This patch re-implements the pull step that will only build development snapshots snaps if the latest tagged release has been promoted to the stable channel.  This ensures that there's always a revision of the stable release snap available in the edge channel for the publisher to promote to stable as currently the automated build infrastructure only supports build on code push (but not new tagged releases) at this time.

The mechanism is inspired from the snapcrafters adopted snaps workflow, documented in the following forum topic:

[The automatic build and pubish process of snaps owned by the Snapcrafters - doc - snapcraft.io](https://forum.snapcraft.io/t/autopublishing-of-snapcrafters-organizations-snaps-how/7954/2)

Refer the following forum topic for a possible solution proposal of this problem:

[Proposal: Allow overriding the source-tag property for an one-time build in the build infrastructure - snapcraft - snapcraft.io](https://forum.snapcraft.io/t/proposal-allow-overriding-the-source-tag-property-for-an-one-time-build-in-the-build-infrastructure/10303)

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>