### PR TITLE
snap: Support official config paths via *-files confinement interfaces

### DIFF
--- a/snap/local/launchers/gallery-dl-launch
+++ b/snap/local/launchers/gallery-dl-launch
@@ -13,30 +13,7 @@ declare REALHOME="$(
 	getent passwd "${USER}" \
 		| cut --delimiter=: --fields=6
 )"
-
-if ! test -f "${SNAP_USER_COMMON}"/.config/gallery-dl/config.json \
-	&& ! test -f "${SNAP_USER_COMMON}"/.gallery-dl.conf; then
-	declare userwide_config_file
-
-	for possible_config_file in \
-		"${REALHOME}"/.config/gallery-dl/config.json \
-		"${REALHOME}"/.gallery-dl.conf; do
-		if test -f "${possible_config_file}"; then
-			userwide_config_file="${possible_config_file}"
-		fi
-	done
-
-	if test -v userwide_config_file; then
-		printf -- \
-			'gallery-dl-launch: It appears that you have a gallery-dl configuration in your home directory, currently the snap distribution of gallery-dl cannot access it until you create a link via running the following command in the terminal:\n\n'
-		printf -- \
-			'gallery-dl-launch:     ln %s %s\n\n' \
-			"${userwide_config_file}" \
-			"~/snap/$SNAP_NAME/common/.gallery-dl.conf"
-	fi
-fi
-
-#HOME="${REALHOME}"
+HOME="${REALHOME}"
 
 # Finally run the next part of the command chain
 exec "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,15 +39,13 @@ plugs:
   network-bind:
 
   # Configuration access
-  # FIXME: Waiting for the Snap Store autoconnection assertion
-  # https://forum.snapcraft.io/t/interface-auto-connection-request-for-the-gallery-dl-snap/10092
-  #personal-files:
-    #read:
-    #- $HOME/.config/gallery-dl
-    #- $HOME/.gallery-dl.conf
-  #system-files:
-    #read:
-    #- /etc/gallery-dl.conf
+  personal-files:
+    read:
+    - $HOME/.config/gallery-dl
+    - $HOME/.gallery-dl.conf
+  system-files:
+    read:
+    - /etc/gallery-dl.conf
 
 parts:
   # Launcher programs to fix problems at runtime


### PR DESCRIPTION
Refer-to: The personal-files interface - doc - snapcraft.io <https://forum.snapcraft.io/t/the-personal-files-interface/9357>
Refer-to: The system-files interface - doc - snapcraft.io <https://forum.snapcraft.io/t/the-system-files-interface/9358>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>