### PR TITLE
snap: Support downloading video using youtube-dl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,8 @@ parts:
     source: .
     override-pull: $SNAPCRAFT_STAGE/scriptlets/selective-pull
     plugin: python
+    python-packages:
+    - youtube_dl
 
   ffmpeg:
     plugin: nil


### PR DESCRIPTION
This patch adds a copy of the youtube-dl package to the snap to enable the video downloading feature.

Tested with the Twitter extractor.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>