### PR TITLE
[instagram] Add support for GraphSidecar media types

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -102,8 +102,7 @@ class InstagramExtractor(Extractor):
 
             for s in shortcodes:
                 url = '{}/p/{}/'.format(self.root, s)
-                for p in self._extract_postpage(url):
-                    yield p
+                yield from self._extract_postpage(url)
 
             if not has_next_page:
                 break

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -18,7 +18,7 @@ class InstagramExtractor(Extractor):
     """Base class for instagram extractors"""
     category = "instagram"
     directory_fmt = ("{category}", "{username}")
-    filename_fmt = "{media_id}.{extension}"
+    filename_fmt = "{sidecar_media_id:?/_/}{media_id}.{extension}"
     archive_fmt = "{media_id}"
     root = "https://www.instagram.com"
 

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -54,8 +54,13 @@ class InstagramExtractor(Extractor):
 
         medias = []
         if media['__typename'] == 'GraphSidecar':
+            yi = 0
             for n in media['edge_sidecar_to_children']['edges']:
                 children = n['node']
+                ytdl_metadata = {}
+                if children['__typename'] == 'GraphVideo':
+                    yi += 1
+                    ytdl_metadata['_ytdl_index'] = yi
                 medias.append({
                     'media_id': children['id'],
                     'shortcode': children['shortcode'],
@@ -66,6 +71,7 @@ class InstagramExtractor(Extractor):
                     'sidecar_media_id': media['id'],
                     'sidecar_shortcode': media['shortcode'],
                     **common,
+                    **ytdl_metadata,
                 })
         else:
             medias.append({


### PR DESCRIPTION
Refactor _extract_postpage() to always return a list of medias.

Fetch common keywords and gracefully handle GraphSidecar media type
by extracting each single media and adding `sidecar_media_id' and
`sidecar_shortcode' keywords to indicate the parent of sidecar
childrens.

While here join the copyright comment lines in a single one.

Closes #178.