### PR TITLE
fixup! Snap packaging improvements (#207)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,10 @@ parts:
     - youtube_dl
     override-build: |
       # build manpages and bash completion
-      make
+      make \
+        gallery-dl.1 \
+        gallery-dl.conf.5 \
+        gallery-dl.bash_completion
 
       snapcraftctl build
 


### PR DESCRIPTION
The build failed due to missing `requests` build dependency, this patch
drops the unused component to build to avoid the problem.

The manpages are still built for the upcoming read-manual workaround.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>