### PR TITLE
snap: Fix scriptlet leaked into the final snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,8 @@ parts:
     - git
     stage-snaps:
     - selective-checkout
+    prime:
+    - -*
 
   gallery-dl:
     after:


### PR DESCRIPTION
The selective-checkout scriptlet is only used during the build step, don't let it make into the final snap.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>