### PR TITLE
description: Change hyperlink markup style

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,9 @@ license: GPL-2.0
 base: core18
 summary: Download image-galleries and -collections from several image hosting sites
 description: |
-  `gallery-dl` is a command-line program to download image-galleries and -collections from several image hosting sites (see [Supported Sites](https://github.com/mikf/gallery-dl/blob/master/docs/supportedsites.rst)). It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
+  `gallery-dl` is a command-line program to download image-galleries and -collections from several image hosting sites (see [Supported Sites][1]). It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
+
+  [1]: https://github.com/mikf/gallery-dl/blob/master/docs/supportedsites.rst
 
 adopt-info: gallery-dl
 confinement: strict


### PR DESCRIPTION
Snap Store no longer supports Markdown's titled hyperlink markup [due to
its ugliness in the `snap info` output in the terminal][1], this patch
changes the description to reference style instead.

[1]:
https://forum.snapcraft.io/t/use-of-markdown-in-snap-metadata-summary-description/2128/23