### PR TITLE
Migrate to core base

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@
 # https://forum.snapcraft.io/c/snapcraft
 name: gallery-dl
 license: GPL-2.0
-base: core18
+base: core
 summary: Download image-galleries and -collections from several image hosting sites
 description: |
   `gallery-dl` is a command-line program to download image-galleries and -collections from several image hosting sites (see [Supported Sites][1]). It is a cross-platform tool with many configuration options and powerful filenaming capabilities.
@@ -92,17 +92,6 @@ parts:
     plugin: nil
     stage-packages:
     - ffmpeg
-    - libavcodec57
-    - libavdevice57
-    - libavfilter6
-    - libavformat57
-    - libavresample3
-    - libavutil55
-    - libpostproc54
-    - libpulse0
-    - libslang2
-    - libswresample2
-    - libswscale4
 
 apps:
   gallery-dl:


### PR DESCRIPTION
Snapcraft now supports a special `core` base for modern snaps to target
on which has the same effect of using the Ubuntu 16.04 based `core` snap
in the past(it is special as the intended base snap to support Ubuntu
16.04 is rather the `core16` base snap, but it isn't ready yet).

This patch migrates the gallery-dl snap to `core` base, which allows the
user to avoid installing the additional `core18` base snap in order to
run it.  It also drops the redundant stage-packages entries that was
collected by Snapcraft automatically in the first place.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>