### PR TITLE
snap: Use descriptive interface reference for *-files plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,11 +41,13 @@ plugs:
   network-bind:
 
   # Configuration access
-  personal-files:
+  config-gallery-dl:
+    interface: personal-files
     read:
     - $HOME/.config/gallery-dl
     - $HOME/.gallery-dl.conf
-  system-files:
+  etc-gallery-dl:
+    interface: system-files
     read:
     - /etc/gallery-dl.conf
 


### PR DESCRIPTION
New Snap Store policy requires *-files interface plugs be named in a specific name.

Fixes #241.

Refer-to: The personal-files interface - doc - snapcraft.io <https://forum.snapcraft.io/t/the-personal-files-interface/9357>
Refer-to: The system-files interface - doc - snapcraft.io <https://forum.snapcraft.io/t/the-system-files-interface/9358>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>