### PR TITLE
[instagram] Fix for missing `edge_media_to_comment' field and add `date' metadata

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -50,6 +50,7 @@ class InstagramExtractor(Extractor):
         media = shared_data['entry_data']['PostPage'][0]['graphql']['shortcode_media']
 
         common = {
+            'date': text.parse_timestamp(media['taken_at_timestamp']),
             'likes': text.parse_int(media['edge_media_preview_like']['count']),
             'owner_id': media['owner']['id'],
             'username': media['owner']['username'],
@@ -172,6 +173,7 @@ class InstagramImageExtractor(InstagramExtractor):
                        r"/vp/[0-9a-f]+/[0-9A-F]+/t51.2885-15/e35"
                        r"/44877605_725955034447492_3123079845831750529_n.jpg",
             "keyword": {
+                "date": "type:datetime",
                 "height": int,
                 "likes": int,
                 "media_id": "1922949326347663701",
@@ -197,6 +199,7 @@ class InstagramImageExtractor(InstagramExtractor):
         ("https://www.instagram.com/p/Bqxp0VSBgJg/", {
             "url": "8f38c1cf460c9804842f7306c487410f33f82e7e",
             "keyword": {
+                "date": "type:datetime",
                 "height": int,
                 "likes": int,
                 "media_id": "1923502432034620000",


### PR DESCRIPTION
Probably since last hours/days (at least the CI has not spotted
that problem yet) the `edge_media_to_comment' field is not always
present in the sharedData JSON.  Sometimes it is present in the
response, other times not, also for the same URL.
Previously, the `count' field of `edge_media_to_comment' was used
to populate `comments' metadata with the number of comments.
For completeness a complete test showing such error will be added
at the end of this pull request.

Add `date' metadata using `taken_at_timestamp' field.


Here the complete output of the failing tests:

````
% env PYTHONPATH=. python3.7 test/test_results.py instagram

https://www.instagram.com/p/BqvsDleB3lV/
.
https://www.instagram.com/p/BoHk1haB5tM/
E
https://www.instagram.com/p/Bqxp0VSBgJg/
.
https://www.instagram.com/p/BtOvDOfhvRr/
.
https://www.instagram.com/explore/tags/instagram/
E
https://www.instagram.com/instagram/
.
======================================================================
ERROR: test_InstagramImageExtractor_2 (__main__.TestExtractorResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_results.py", line 258, in test
    self._run_test(extr, url, result)
  File "test/test_results.py", line 61, in _run_test
    tjob.run()
  File "test/test_results.py", line 152, in run
    for msg in self.extractor:
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 32, in items
    for data in self.instagrams():
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 232, in instagrams
    return self._extract_postpage(url)
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 53, in _extract_postpage
    'comments': text.parse_int(media['edge_media_to_comment']['count']),
KeyError: 'edge_media_to_comment'

======================================================================
ERROR: test_InstagramTagExtractor_1 (__main__.TestExtractorResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_results.py", line 258, in test
    self._run_test(extr, url, result)
  File "test/test_results.py", line 61, in _run_test
    tjob.run()
  File "test/test_results.py", line 152, in run
    for msg in self.extractor:
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 32, in items
    for data in self.instagrams():
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 162, in _extract_tagpage
    yield from self._extract_page(url, 'TagPage')
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 135, in _extract_page
    yield from self._extract_postpage(url)
  File ".../gallery-dl/gallery_dl/extractor/instagram.py", line 53, in _extract_postpage
    'comments': text.parse_int(media['edge_media_to_comment']['count']),
KeyError: 'edge_media_to_comment'

----------------------------------------------------------------------
Ran 6 tests in 11.946s

FAILED (errors=2)
````