### PR TITLE
Fix `--write-metadata` option to support extractors with `datetime` metadata

### DIFF
--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -10,6 +10,7 @@
 
 from .common import PostProcessor
 from .. import util
+import datetime
 import json
 
 
@@ -61,12 +62,20 @@ class MetadataPP(PostProcessor):
         file.write("\n")
 
     def _write_json(self, file, pathfmt):
+        class GalleryDLJSONEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, datetime.datetime):
+                    return obj.isoformat()
+                # Let the base class default method raise the TypeError
+                return json.JSONEncoder.default(self, obj)
+
         json.dump(
             pathfmt.keywords,
             file,
             sort_keys=True,
             indent=self.indent,
             ensure_ascii=self.ascii,
+            cls=GalleryDLJSONEncoder,
         )
 
 


### PR DESCRIPTION
When using `--write-metadata` option with extractors that have
`datetime` metadata `gallery-dl` fails to encode JSON because json.dump() can
not serialize them, e.g.:

````
% env PYTHONPATH=. python3.7 -m gallery_dl --verbose --write-metadata 'https://www.instagram.com/p/BqvsDleB3lV/'
[...]
[instagram][debug]
Traceback (most recent call last):
  File ".../gallery-dl/gallery_dl/job.py", line 55, in run
    self.dispatch(msg)
  File ".../gallery-dl/gallery_dl/job.py", line 99, in dispatch
    self.handle_url(url, kwds)
  File ".../gallery-dl/gallery_dl/job.py", line 230, in handle_url
    pp.run(self.pathfmt)
  File ".../gallery-dl/gallery_dl/postprocessor/metadata.py", line 40, in run
    self.write(file, pathfmt)
  File ".../gallery-dl/gallery_dl/postprocessor/metadata.py", line 69, in _write_json
    ensure_ascii=self.ascii,
  File ".../json/__init__.py", line 179, in dump
    for chunk in iterable:
  File ".../json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File ".../json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File ".../json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File ".../json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
````

This pull request introduce a GalleryDLJSONEncoder that serialize
datetime.datetime objects as ISO 8601 strings.

In the future - if needed - this can be extended to support more
non-basic types.