### PR TITLE
[instagram] Fix extraction after `rhx_gis' field removal

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -120,8 +120,7 @@ class InstagramExtractor(Extractor):
             if 'entry_data' in shared_data:
                 base_shared_data = shared_data['entry_data'][page_type][0]['graphql']
 
-                # `rhx_gis' and variables_id are available only in the first page
-                rhx_gis = shared_data['rhx_gis']
+                # variables_id is available only in the first page
                 variables_id = base_shared_data[psdf['node']][psdf['node_id']]
             else:
                 base_shared_data = shared_data['data']
@@ -143,10 +142,9 @@ class InstagramExtractor(Extractor):
                 variables_id,
                 end_cursor,
             )
-            xigis = '{}:{}'.format(rhx_gis, variables)
             headers = {
                 "X-Requested-With": "XMLHttpRequest",
-                "X-Instagram-GIS": hashlib.md5(xigis.encode()).hexdigest(),
+                "X-Instagram-GIS": hashlib.md5(variables.encode()).hexdigest(),
             }
             url = '{}/graphql/query/?query_hash={}&variables={}'.format(
                 self.root,


### PR DESCRIPTION
Instagram has recently removed the `rhx_gis' in sharedData JSON
leading to extraction failures for tags and profiles.

Adjust `X-Instagram-GIS' header generation accordingly.

For completeness here the failure of the tests:

````
% env PYTHONPATH=. python3.7 test/test_results.py instagram

https://www.instagram.com/p/BqvsDleB3lV/
.
https://www.instagram.com/p/BoHk1haB5tM/
.
https://www.instagram.com/p/Bqxp0VSBgJg/
.
https://www.instagram.com/p/BtOvDOfhvRr/
.
https://www.instagram.com/explore/tags/instagram/
E
https://www.instagram.com/instagram/
E
======================================================================
ERROR: test_InstagramTagExtractor_1 (__main__.TestExtractorResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_results.py", line 259, in test
    self._run_test(extr, url, result)
  File "test/test_results.py", line 62, in _run_test
    tjob.run()
  File "test/test_results.py", line 153, in run
    for msg in self.extractor:
  File ".../gallery_dl/extractor/instagram.py", line 32, in items
    for data in self.instagrams():
  File ".../gallery_dl/extractor/instagram.py", line 162, in _extract_tagpage
    yield from self._extract_page(url, 'TagPage')
  File ".../gallery_dl/extractor/instagram.py", line 124, in _extract_page
    rhx_gis = shared_data['rhx_gis']
KeyError: 'rhx_gis'

======================================================================
ERROR: test_InstagramUserExtractor_1 (__main__.TestExtractorResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_results.py", line 259, in test
    self._run_test(extr, url, result)
  File "test/test_results.py", line 62, in _run_test
    tjob.run()
  File "test/test_results.py", line 153, in run
    for msg in self.extractor:
  File ".../gallery_dl/extractor/instagram.py", line 32, in items
    for data in self.instagrams():
  File ".../gallery_dl/extractor/instagram.py", line 159, in _extract_profilepage
    yield from self._extract_page(url, 'ProfilePage')
  File ".../gallery_dl/extractor/instagram.py", line 124, in _extract_page
    rhx_gis = shared_data['rhx_gis']
KeyError: 'rhx_gis'

----------------------------------------------------------------------
Ran 6 tests in 5.687s

FAILED (errors=2)
````