### PR TITLE
Added an additional channel for downloading the metadata of an entire post or gallery

### DIFF
--- a/gallery_dl/extractor/message.py
+++ b/gallery_dl/extractor/message.py
@@ -52,3 +52,4 @@ class Message():
     #  Cookies = 5
     Queue = 6
     Urllist = 7
+    Metadata = 8

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -69,6 +69,7 @@ class PatreonExtractor(Extractor):
                     post["type"] = "content"
                     yield Message.Url, url, text.nameext_from_url(url, post)
 
+            # Metadata for post using dummy url for formatting
             post.update({"metadata_only": True})
             url = post.get("creator").get("image_url")
             yield Message.Metadata, url, text.nameext_from_url(url, post)

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -69,6 +69,10 @@ class PatreonExtractor(Extractor):
                     post["type"] = "content"
                     yield Message.Url, url, text.nameext_from_url(url, post)
 
+            post.update({"metadata_only": True})
+            url = post.get("creator").get("image_url")
+            yield Message.Metadata, url, text.nameext_from_url(url, post)
+
     def posts(self):
         """Return all relevant post objects"""
 

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -195,7 +195,6 @@ class DownloadJob(Job):
                 pp.prepare(pathfmt)
 
         if kwdict.get("metadata_only"):
-            self.handle_skip()
             return
 
         if pathfmt.exists(archive):

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -97,6 +97,12 @@ class Job():
                 self.update_kwdict(kwds)
                 self.handle_urllist(urls, kwds)
 
+        elif msg[0] == Message.Metadata:
+            _, url, kwds = msg
+            if self.pred_url(url, kwds):
+                self.update_kwdict(kwds)
+                self.handle_url(url, kwds)
+
         elif msg[0] == Message.Version:
             if msg[1] != 1:
                 raise "unsupported message-version ({}, {})".format(
@@ -187,6 +193,10 @@ class DownloadJob(Job):
         if postprocessors:
             for pp in postprocessors:
                 pp.prepare(pathfmt)
+
+        if kwdict.get("metadata_only"):
+            self.handle_skip()
+            return
 
         if pathfmt.exists(archive):
             self.handle_skip()

--- a/gallery_dl/postprocessor/__init__.py
+++ b/gallery_dl/postprocessor/__init__.py
@@ -18,6 +18,7 @@ modules = [
     "mtime",
     "ugoira",
     "zip",
+    "metadata_bypost",
 ]
 
 log = logging.getLogger("postprocessor")

--- a/gallery_dl/postprocessor/metadata_bypost.py
+++ b/gallery_dl/postprocessor/metadata_bypost.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Mike Fährmann
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Write metadata to JSON files"""
+
+from .metadata import __postprocessor__ as MetadataPP
+
+
+class Metadata_BypostPP(MetadataPP):
+
+    def __init__(self, pathfmt, options):
+        MetadataPP.__init__(self, pathfmt, options)
+
+    def prepare(self, pathfmt):
+        if pathfmt.kwdict.get("metadata_only"):
+            MetadataPP.run(self, pathfmt)
+
+    def run(self, pathfmt):
+         return
+
+__postprocessor__ = Metadata_BypostPP

--- a/gallery_dl/postprocessor/metadata_bypost.py
+++ b/gallery_dl/postprocessor/metadata_bypost.py
@@ -11,7 +11,7 @@
 from .metadata import __postprocessor__ as MetadataPP
 
 
-class Metadata_BypostPP(MetadataPP):
+class Metadata_bypostPP(MetadataPP):
 
     def __init__(self, pathfmt, options):
         MetadataPP.__init__(self, pathfmt, options)
@@ -23,4 +23,4 @@ class Metadata_BypostPP(MetadataPP):
     def run(self, pathfmt):
          return
 
-__postprocessor__ = Metadata_BypostPP
+__postprocessor__ = Metadata_bypostPP

--- a/gallery_dl/postprocessor/metadata_bypost.py
+++ b/gallery_dl/postprocessor/metadata_bypost.py
@@ -8,20 +8,73 @@
 
 """Write metadata to JSON files"""
 
-from .metadata import __postprocessor__ as MetadataPP
+from .common import PostProcessor
+from .. import util
 
-
-class Metadata_bypostPP(MetadataPP):
+class Metadata_bypostPP(PostProcessor):
 
     def __init__(self, pathfmt, options):
-        MetadataPP.__init__(self, pathfmt, options)
+        PostProcessor.__init__(self)
+
+        mode = options.get("mode", "json")
+        if mode == "custom":
+            self.write = self._write_custom
+            cfmt = options.get("content-format") or options.get("format")
+            self.contentfmt = util.Formatter(cfmt).format_map
+            ext = "txt"
+        elif mode == "tags":
+            self.write = self._write_tags
+            ext = "txt"
+        else:
+            self.write = self._write_json
+            self.indent = options.get("indent", 4)
+            self.ascii = options.get("ascii", False)
+            ext = "json"
+
+        extfmt = options.get("extension-format")
+        if extfmt:
+            self.path = self._path_format
+            self.extfmt = util.Formatter(extfmt).format_map
+        else:
+            self.path = self._path_append
+            self.extension = options.get("extension", ext)
 
     def prepare(self, pathfmt):
-        # Only run this processor on metadata messages, not individual images.
-        if pathfmt.kwdict.get("metadata_only"):
-            MetadataPP.run(self, pathfmt)
+        with open(self.path(pathfmt), "w", encoding="utf-8") as file:
+            self.write(file, pathfmt.kwdict)
 
-    def run(self, pathfmt):
-         return
+    def _path_append(self, pathfmt):
+        return "{}.{}".format(pathfmt.realpath, self.extension)
+
+    def _path_format(self, pathfmt):
+        kwdict = pathfmt.kwdict
+        ext = kwdict["extension"]
+        kwdict["extension"] = pathfmt.extension
+        kwdict["extension"] = pathfmt.prefix + self.extfmt(kwdict)
+        path = pathfmt.realdirectory + pathfmt.build_filename()
+        kwdict["extension"] = ext
+        return path
+
+    def _write_custom(self, file, kwdict):
+        file.write(self.contentfmt(kwdict))
+
+    def _write_tags(self, file, kwdict):
+        tags = kwdict.get("tags") or kwdict.get("tag_string")
+
+        if not tags:
+            return
+
+        if not isinstance(tags, list):
+            taglist = tags.split(", ")
+            if len(taglist) < len(tags) / 16:
+                taglist = tags.split(" ")
+            tags = taglist
+
+        file.write("\n".join(tags))
+        file.write("\n")
+
+    def _write_json(self, file, kwdict):
+        util.dump_json(util.filter_dict(kwdict), file, self.ascii, self.indent)
+
 
 __postprocessor__ = Metadata_bypostPP

--- a/gallery_dl/postprocessor/metadata_bypost.py
+++ b/gallery_dl/postprocessor/metadata_bypost.py
@@ -17,6 +17,7 @@ class Metadata_bypostPP(MetadataPP):
         MetadataPP.__init__(self, pathfmt, options)
 
     def prepare(self, pathfmt):
+        # Only run this processor on metadata messages, not individual images.
         if pathfmt.kwdict.get("metadata_only"):
             MetadataPP.run(self, pathfmt)
 


### PR DESCRIPTION
This is a potential way to resolve #461 

Uses a new message, `Metadata`, a new kwarg, `metadata_only`, and a new "postprocessor", `Metadata_Bypost`.

The preprocessor only uses the `prepare` function, so it does not depend on a successful file download.

Messages go through the standard `handle_url` route, and `handle_url` calls all postprocessor `prepare` functions. Then, if the `metadata_only` flag is set, it exits prematurely (like it does when the file exists.)

When this postprocessor is enabled (without the `Metadata` postprocessor at all), metadata is correctly saved for each post once, including posts that don't have any other media to download. 