### PR TITLE
Handle cookies with an expiry of 0

### DIFF
--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -199,7 +199,10 @@ class Extractor():
                 cookiefile = util.expand_path(cookies)
                 cookiejar = http.cookiejar.MozillaCookieJar()
                 try:
-                    cookiejar.load(cookiefile)
+                    cookiejar.load(cookiefile, ignore_expires=True)
+                    for cookie in cookiejar:
+                        if cookie.is_expired() and not cookie.is_expired(0):
+                            cookiejar.clear(cookie.domain, cookie.path, cookie.name)
                 except OSError as exc:
                     self.log.warning("cookies: %s", exc)
                 else:
@@ -222,7 +225,7 @@ class Extractor():
             for cookie in self._cookiejar:
                 cookiejar.set_cookie(cookie)
             try:
-                cookiejar.save(self._cookiefile)
+                cookiejar.save(self._cookiefile, ignore_expires=True)
             except OSError as exc:
                 self.log.warning("cookies: %s", exc)
 


### PR DESCRIPTION
I could not figure out why gallery-dl would not recognize my DA cookie. After a lot of debugging, I discovered that auth and auth_secure were being discarded because Python's http.cookiejar library considers an expiry of 0 to mean the cookie is expired.

My solution was to pass ignore_expires=True to both the loading and saving of the cookiejar, and simply discarded expired cookies (that don't have an expiry of 0) with a for loop after the load.