### PR TITLE
New option map invalid path chars to alternatives.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -125,7 +125,7 @@ extractor.*.path-restrict
 Type        ``string``
 Default     ``"auto"``
 Example     ``"/!? (){}"``
-Description Set of characters to replace with underscores (``_``)
+Description Set of characters replaced by ``path-restrict-replace``
             in generated path segment names.
 
             Special values:
@@ -137,6 +137,34 @@ Description Set of characters to replace with underscores (``_``)
 
             Note: In a set with 2 or more characters, ``[]^-\`` need to be
             escaped with backslashes, e.g. ``"\\[\\]"``
+=========== =====
+
+
+extractor.*.path-restrict-replace
+---------------------------------
+=========== =====
+Type        ``string``
+Default     ``"_"``
+Example     ``"map"``
+Description To replace characters in ``path-restrict``.
+
+            Special values:
+
+            * ``"map"``: Invalid characters in path will be mapped to their unicode alternatives, according to the following dict:
+
+            ::
+
+                PATH_INVALID_CHAR_REPLACEMENT = {
+                    '\\': '⧹',  # U+29F9 (big reverse solidus)
+                    '/': '⧸',  # U+29F8 (big solidus, permitted in Windows file and folder names）
+                    '|': '￨',  # U+FFE8 (halfwidth forms light vertical)
+                    ':': '꞉',  # U+A789 (modifier letter colon, sometimes used in Windows filenames)
+                    '*': '∗',  # U+2217 (asterisk operator)
+                    '?': '？',  # U+FF1F (full-width question mark)
+                    '"': '″',  # U+2033 (DOUBLE PRIME)
+                    '<': '﹤',  # U+FE64 (small less-than sign)
+                    '>': '﹥',  # U+FE65 (small greater-than sign)
+                }
 =========== =====
 
 

--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -26,6 +26,23 @@ from email.utils import mktime_tz, parsedate_tz
 from . import text, exception
 
 
+PATH_INVALID_CHAR_REPLACEMENT = {
+    '\\': '⧹',  # U+29F9 (big reverse solidus)
+    '/': '⧸',  # U+29F8 (big solidus, permitted in Windows file and folder names）
+    '|': '￨',  # U+FFE8 (halfwidth forms light vertical)
+    ':': '꞉',  # U+A789 (modifier letter colon, sometimes used in Windows filenames)
+    '*': '∗',  # U+2217 (asterisk operator)
+    '?': '？',  # U+FF1F (full-width question mark)
+    '"': '″',  # U+2033 (DOUBLE PRIME)
+    '<': '﹤',  # U+FE64 (small less-than sign)
+    '>': '﹥',  # U+FE65 (small greater-than sign)
+}
+
+
+def string_map(s: str):
+    return ''.join([PATH_INVALID_CHAR_REPLACEMENT.get(c, c) for c in s])
+
+
 def bencode(num, alphabet="0123456789"):
     """Encode an integer into a base-N encoded string"""
     data = ""
@@ -681,7 +698,12 @@ class PathFormat():
 
         remove = extractor.config("path-remove", "\x00-\x1f\x7f")
 
-        self.clean_segment = self._build_cleanfunc(restrict, "_")
+        restrict_by = extractor.config('path-restrict-replace', '_')
+        if restrict_by == 'map':
+            self.clean_segment = string_map
+        else:
+            self.clean_segment = self._build_cleanfunc(restrict, restrict_by)
+
         self.clean_path = self._build_cleanfunc(remove, "")
 
     @staticmethod


### PR DESCRIPTION
option `path-restrict-replace`, by default, being `_`, will replace all
invalid chars in path into `_`; when set to `map`, instead of replacing
invalid chars uniformly into one same char, will map them individually
into their similar unicode alternatives.