### PR TITLE
[webtoons] make archive_fmt unique

### DIFF
--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -33,7 +33,7 @@ class WebtoonsEpisodeExtractor(WebtoonsExtractor):
     subcategory = "episode"
     directory_fmt = ("{category}", "{comic}")
     filename_fmt = "{episode}-{num:>02}.{extension}"
-    archive_fmt = "{episode}_{num}"
+    archive_fmt = "{title_no}_{episode}_{num}"
     pattern = (BASE_PATTERN + r"/([^/?&#]+)/([^/?&#]+)/(?:[^/?&#]+))"
                r"/viewer(?:\?([^#]+))")
     test = (


### PR DESCRIPTION
Also use {comic} and {title_no} in the archive_fmt ({comic} can be the same for
multi-language comics but {title_no} seems different in these cases, so the
former could be helpful as a "text description" while the latter should make it
unique).

CLose #778

E.g.:

 https://www.webtoons.com/en/romance/subzero/episode-35/viewer?title_no=1468&episode_no=40
 https://www.webtoons.com/fr/romance/subzero/episode-35/viewer?title_no=1845&episode_no=38