### PR TITLE
Only run oauth tests if a connection succeeds

### DIFF
--- a/test/test_oauth.py
+++ b/test/test_oauth.py
@@ -101,7 +101,11 @@ class TestOAuthSession(unittest.TestCase):
             oauth_token, oauth_token_secret,
         )
         try:
-            return session.get(TESTSERVER + endpoint, params=params).text
+            connection = session.get(TESTSERVER + endpoint, params=params)
+            if connection.status_code == 200:
+                return connection.text
+            else:
+                raise unittest.SkipTest()
         except OSError:
             raise unittest.SkipTest()
 


### PR DESCRIPTION
In the autopkgtest infrastructure for Ubuntu we use a squid proxy and were not receiving an OSError in _oauth_request but instead were receiving a 403 status code. Regardless, checking for the status_code of the session.get() call seems like a good idea in general.