### PR TITLE
[aryion] Add username/password support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,7 +205,7 @@ Some extractors require you to provide valid login credentials in the form of
 a username & password pair. This is necessary for
 ``pixiv``, ``nijie``, and ``seiga``
 and optional for
-``danbooru``, ``e621``, ``exhentai``, ``idolcomplex``, ``inkbunny``,
+``aryion``, ``danbooru``, ``e621``, ``exhentai``, ``idolcomplex``, ``inkbunny``,
 ``instagram``, ``luscious``, ``sankaku``, ``subscribestar``, ``tsumino``,
 and ``twitter``.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -224,6 +224,7 @@ Description The username and password to use when attempting to log in to
 
             and optional for
 
+            * ``aryion``
             * ``danbooru``
             * ``e621``
             * ``exhentai``

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -18,6 +18,11 @@
         {
             "external": false
         },
+        "aryion":
+        {
+            "username": null,
+            "password": null
+        },
         "blogger":
         {
             "videos": true

--- a/docs/supportedsites.rst
+++ b/docs/supportedsites.rst
@@ -28,7 +28,7 @@ Doki Reader          https://kobato.hologfx.com/reader/  Chapters, Manga
 Dynasty Reader       https://dynasty-scans.com/          Chapters, individual Images, Search Results
 E-Hentai             https://e-hentai.org/               Favorites, Galleries, Search Results               Optional
 e621                 https://e621.net/                   Pools, Popular Images, Posts, Tag Searches         Optional
-Eka's Portal         https://aryion.com/                 Galleries, Posts                                   Optional (`Cookies <https://github.com/mikf/gallery-dl#cookies>`__)
+Eka's Portal         https://aryion.com/                 Galleries, Posts                                   Optional
 ExHentai             https://exhentai.org/               Favorites, Galleries, Search Results               Optional
 Fallen Angels Scans  https://www.fascans.com/            Chapters, Manga
 Fashion Nova         https://www.fashionnova.com/        Collections, Products

--- a/gallery_dl/extractor/aryion.py
+++ b/gallery_dl/extractor/aryion.py
@@ -30,12 +30,12 @@ class AryionExtractor(Extractor):
         Extractor.__init__(self, match)
         self.user = match.group(1)
         self.recursive = True
-        
+
     def login(self):
         username, password = self._get_auth_info()
         if username:
             self._update_cookies(self._login_impl(username, password))
-    
+
     @cache(maxage=14*24*3600, keyarg=1)
     def _login_impl(self, username, password):
         self.log.info("Logging in as %s", username)
@@ -50,7 +50,7 @@ class AryionExtractor(Extractor):
         response = self.request(url, method="POST", data=data)
         if b"You have been successfully logged in." not in response.content:
             raise exception.AuthenticationError()
-        return { c: response.cookies[c] for c in self.cookienames }
+        return {c: response.cookies[c] for c in self.cookienames}
 
     def items(self):
         self.login()

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -149,7 +149,7 @@ _COOKIES = " (`Cookies <https://github.com/mikf/gallery-dl#cookies>`__)"
 _APIKEY_WH = " (`API Key <configuration.rst#extractorwallhavenapi-key>`__)"
 
 AUTH_MAP = {
-    "aryion"         : "Optional" + _COOKIES,
+    "aryion"         : "Optional",
     "baraag"         : "Optional" + _OAUTH,
     "danbooru"       : "Optional",
     "deviantart"     : "Optional" + _OAUTH,


### PR DESCRIPTION
Implements login with username and password, instead of needing to export browser cookies.
While authentication is not absolutely required, posts on Eka's Portal can be made private or hidden from users who are not logged in.