### PR TITLE
[aryion] get post ID via gallery-item (Fixes #981)

### DIFF
--- a/gallery_dl/extractor/aryion.py
+++ b/gallery_dl/extractor/aryion.py
@@ -73,7 +73,7 @@ class AryionExtractor(Extractor):
         while True:
             page = self.request(url).text
             yield from text.extract_iter(
-                page, "class='thumb' href='/g4/view/", "'")
+                page, "class='gallery-item' id='", "'")
 
             pos = page.find("Next &gt;&gt;")
             if pos < 0:


### PR DESCRIPTION
This makes gallery-dl able to get aryion posts lacking a thumbnail, such as many text documents.