### PR TITLE
snap: Fix selective-checkout unable to build development snapshots

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,14 +59,20 @@ parts:
     organize:
       '*': bin/
 
-  # Check out the tagged release revision if it isn’t promoted to the stable channel
+  # Check out the tagged release revision if it isn't promoted to the stable channel
   # https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
   selective-checkout:
-    plugin: nil
+    source: https://github.com/Lin-Buo-Ren/selective-checkout.git
+    source-tag: v2.0.0
+    plugin: dump
     build-packages:
+    # Scriptlet dependencies
+    - curl
     - git
-    stage-snaps:
-    - selective-checkout
+    - jq
+    - sed
+    stage:
+    - scriptlets/selective-checkout
     prime:
     - -*
 


### PR DESCRIPTION
Due to recent `snap info` command output changes selective-checkout no
longer can match the stable channel version, which, making it always
building stable releases even when it is being promoted to the stable
channel.

This patch fixes the problem by upgrading the part to the new version, which
now call the Snap Store API for the info instead of scraping `snap info gallery-dl`
command's output, which should ensure stability in the future.

Refer-to: Selective-checkout: Check out the tagged release revision if it isn't promoted to the stable channel - doc - snapcraft.io <https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>