### PR TITLE
[reactor] match URLs without subdomain

### DIFF
--- a/gallery_dl/extractor/reactor.py
+++ b/gallery_dl/extractor/reactor.py
@@ -16,7 +16,7 @@ import time
 import json
 
 
-BASE_PATTERN = r"(?:https?://)?([^/.]+\.reactor\.cc)"
+BASE_PATTERN = r"(?:https?://)?((?:[^/.]+\.)?reactor\.cc)"
 
 
 class ReactorExtractor(SharedConfigMixin, Extractor):


### PR DESCRIPTION
Currently, the extractor doesn't work for URLs with no subdomain, such as http://reactor.cc/post/4525538.
This PR fixes it.