### PR TITLE
[e621] add keyword 'num' for post order in pool

### DIFF
--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -147,7 +147,6 @@ class DanbooruPoolExtractor(DanbooruExtractor):
         url = "{}/pools/{}.json".format(self.root, self.pool_id)
         pool = self.request(url).json()
         pool["name"] = pool["name"].replace("_", " ")
-        del pool["post_ids"]
         return {"pool": pool}
 
 

--- a/gallery_dl/extractor/e621.py
+++ b/gallery_dl/extractor/e621.py
@@ -35,7 +35,7 @@ class E621Extractor(danbooru.DanbooruExtractor):
 
     def items(self):
         data = self.metadata()
-        for post in self.posts():
+        for num, post in enumerate(self.posts(), start=1):
             file = post["file"]
 
             if not file["url"]:
@@ -43,12 +43,20 @@ class E621Extractor(danbooru.DanbooruExtractor):
                 file["url"] = "https://static1.{}/data/{}/{}/{}.{}".format(
                     self.root[8:], ihash[0:2], ihash[2:4], ihash, file["ext"])
 
+            post["num"] = num
             post["filename"] = file["md5"]
             post["extension"] = file["ext"]
             post.update(data)
             yield Message.Directory, post
             yield Message.Url, file["url"], post
 
+    def posts(self):
+        data = self.metadata()
+        if "pool" in data and "post_ids" in data["pool"]:
+            post_order = dict([(id, index) for index, id in enumerate(data["pool"]["post_ids"])])
+            return sorted(super().posts(), key=lambda post: post_order[post["id"]])
+        else:
+            return super().posts()
 
 class E621TagExtractor(E621Extractor, danbooru.DanbooruTagExtractor):
     """Extractor for e621 posts from tag searches"""

--- a/gallery_dl/extractor/e621.py
+++ b/gallery_dl/extractor/e621.py
@@ -51,12 +51,16 @@ class E621Extractor(danbooru.DanbooruExtractor):
             yield Message.Url, file["url"], post
 
     def posts(self):
+        posts = super().posts()
         data = self.metadata()
+
         if "pool" in data and "post_ids" in data["pool"]:
-            post_order = dict([(id, index) for index, id in enumerate(data["pool"]["post_ids"])])
-            return sorted(super().posts(), key=lambda post: post_order[post["id"]])
+            post_ids = data["pool"]["post_ids"]
+            post_order = dict([(id, pos) for pos, id in enumerate(post_ids)])
+            return sorted(posts, key=lambda post: post_order[post["id"]])
         else:
-            return super().posts()
+            return posts
+
 
 class E621TagExtractor(E621Extractor, danbooru.DanbooruTagExtractor):
     """Extractor for e621 posts from tag searches"""


### PR DESCRIPTION
Pools in e621 have an explicit post order.

This PR exposes each post's index with the `num` keyword.

Useful for keeping comic pages in the correct order.

Example usage:

```json
"pool": {
	"directory": [ "{category}", "pool", "{tags[artist]:J, /}", "{pool[id]} {pool[name]}" ],
	"filename": "{num}.{extension}"
}
```