### PR TITLE
[snap] allow access user's .netrc for site authentication

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,10 @@ plugs:
     interface: system-files
     read:
     - /etc/gallery-dl.conf
+  dot-netrc:
+    interface: personal-files
+    read:
+    - $HOME/.netrc
 
 parts:
   # Launcher programs to fix problems at runtime


### PR DESCRIPTION
The `personal-files` interface ~~autoconnect~~ request is [granted by the Snap Store](https://forum.snapcraft.io/t/interface-auto-connect-request-for-the-gallery-dl-snap-personal-files-netrc/20038/8).

Fixes #759.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>