### PR TITLE
Adding handling of several input files

### DIFF
--- a/gallery_dl/__init__.py
+++ b/gallery_dl/__init__.py
@@ -196,7 +196,7 @@ def main():
                     cnt, "entry" if cnt == 1 else "entries", cache._path(),
                 )
         else:
-            if not args.urls and not args.inputfile:
+            if not args.urls and not args.inputfiles:
                 parser.error(
                     "The following arguments are required: URL\n"
                     "Use 'gallery-dl --help' to get a list of all options.")
@@ -208,18 +208,19 @@ def main():
                 jobtype = args.jobtype or job.DownloadJob
 
             urls = args.urls
-            if args.inputfile:
-                try:
-                    if args.inputfile == "-":
-                        if sys.stdin:
-                            urls += parse_inputfile(sys.stdin, log)
+            if args.inputfiles:
+                for inputfile in args.inputfiles:
+                    try:
+                        if inputfile == "-":
+                            if sys.stdin:
+                                urls += parse_inputfile(sys.stdin, log)
+                            else:
+                                log.warning("input file: stdin is not readable")
                         else:
-                            log.warning("input file: stdin is not readable")
-                    else:
-                        with open(args.inputfile, encoding="utf-8") as file:
-                            urls += parse_inputfile(file, log)
-                except OSError as exc:
-                    log.warning("input file: %s", exc)
+                            with open(inputfile, encoding="utf-8") as file:
+                                urls += parse_inputfile(file, log)
+                    except OSError as exc:
+                        log.warning("input file: %s", exc)
 
             # unsupported file logging handler
             handler = output.setup_logging_handler(

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -100,7 +100,7 @@ def build_parser():
         "-i", "--input-file",
         dest="inputfiles", metavar="FILE", action="append",
         help=("Download URLs found in FILE ('-' for stdin). "
-             "More than one --input-file can be specified"),
+              "More than one --input-file can be specified"),
     )
     general.add_argument(
         "--cookies",

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -98,8 +98,9 @@ def build_parser():
     )
     general.add_argument(
         "-i", "--input-file",
-        dest="inputfile", metavar="FILE",
-        help="Download URLs found in FILE ('-' for stdin)",
+        dest="inputfiles", metavar="FILE", action="append",
+        help=("Download URLs found in FILE ('-' for stdin). "
+             "More than one --input-file can be specified"),
     )
     general.add_argument(
         "--cookies",


### PR DESCRIPTION
This change allows several input files to be specified, like this:

`gallery-dl -i file1.txt -i file2.txt`

If more than one file is specified, `main()` will iterate over the list of files and append the lines of one file after the previous one.