### PR TITLE
Weasyl: Drop the `&feature=submit` part of the favourite extractor URL

### DIFF
--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -203,7 +203,7 @@ class WeasylJournalsExtractor(WeasylExtractor):
 class WeasylFavoriteExtractor(WeasylExtractor):
     subcategory = "favorite"
     directory_fmt = ("{category}", "{owner_login}", "Favorites")
-    pattern = BASE_PATTERN + r"favorites\?userid=(\d+)&feature=submit"
+    pattern = BASE_PATTERN + r"favorites\?userid=(\d+)"
     test = ("https://www.weasyl.com/favorites?userid=184616&feature=submit", {
         "count": ">= 5",
     })


### PR DESCRIPTION
It's optional and requiring it forces users to escape those URLs because
of the ampersand