### PR TITLE
fix PixivFavoriteExtractor regex

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -254,8 +254,9 @@ class PixivFavoriteExtractor(PixivExtractor):
                      "{user_bookmark[id]} {user_bookmark[account]}")
     archive_fmt = "f_{user_bookmark[id]}_{id}{num}.{extension}"
     pattern = (r"(?:https?://)?(?:www\.|touch\.)?pixiv\.net/(?:(?:en/)?"
-               r"users/(\d+)/(bookmarks/artworks(?:/([^/?#]+))?|following)"
-               r"|bookmark\.php(?:\?([^#]*))?)")
+               r"users/(\d+)/(bookmarks/artworks|following)"
+               r"|bookmark\.php)(?:(?<=bookmarks/artworks)"
+               r"(?:/([^/?#]+)))?(?:\?([^#]*))?")
     test = (
         ("https://www.pixiv.net/en/users/173530/bookmarks/artworks", {
             "url": "e717eb511500f2fa3497aaee796a468ecf685cc4",

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -254,9 +254,8 @@ class PixivFavoriteExtractor(PixivExtractor):
                      "{user_bookmark[id]} {user_bookmark[account]}")
     archive_fmt = "f_{user_bookmark[id]}_{id}{num}.{extension}"
     pattern = (r"(?:https?://)?(?:www\.|touch\.)?pixiv\.net/(?:(?:en/)?"
-               r"users/(\d+)/(bookmarks/artworks|following)"
-               r"|bookmark\.php)(?:(?<=bookmarks/artworks)"
-               r"(?:/([^/?#]+)))?(?:\?([^#]*))?")
+               r"users/(\d+)/(bookmarks/artworks|following)(?:/([^/?#]+))?"
+               r"|bookmark\.php)(?:\?([^#]*))?")
     test = (
         ("https://www.pixiv.net/en/users/173530/bookmarks/artworks", {
             "url": "e717eb511500f2fa3497aaee796a468ecf685cc4",


### PR DESCRIPTION
Output below is the matches of each URL in a list [uid, kind, self.tag, query], based on
https://github.com/mikf/gallery-dl/blob/91c2e15da9175c11ca2b9178dda20acf2e5eda5d/gallery_dl/extractor/pixiv.py#L300

Before:
```
https://www.pixiv.net/en/users/173530/bookmarks/artworks ['173530', 'bookmarks/artworks', None, None]
https://www.pixiv.net/bookmark.php?id=173530 [None, None, None, 'id=173530']
No match: https://www.pixiv.net/en/users/3137110
https://www.pixiv.net/bookmark.php?id=3137110&tag=%E3%81%AF%E3%82%93%E3%82%82%E3%82%93&p=1 [None, None, None,
'id=3137110&tag=%E3%81%AF%E3%82%93%E3%82%82%E3%82%93&p=1']
https://www.pixiv.net/bookmark.php [None, None, None, None]
https://www.pixiv.net/bookmark.php?tag=foobar [None, None, None, 'tag=foobar']
https://www.pixiv.net/en/users/173530/following ['173530', 'following', None, None]
https://www.pixiv.net/bookmark.php?id=173530&type=user [None, None, None, 'id=173530&type=user']
https://touch.pixiv.net/bookmark.php?id=173530 [None, None, None, 'id=173530']
https://touch.pixiv.net/bookmark.php [None, None, None, None]
https://www.pixiv.net/en/users/173530/bookmarks/artworks?rest=hide ['173530', 'bookmarks/artworks', None,
None]
https://www.pixiv.net/en/users/173530/bookmarks/artworks/未分類?rest=hide ['173530', 'bookmarks/artworks/>
未分類', '未分類', None]
```

Of note: 
- `https://www.pixiv.net/en/users/173530/bookmarks/artworks?rest=hide ['173530', 'bookmarks/artworks', None,
None]` -> does not group "hide" option (private bookmarks)
- `https://www.pixiv.net/en/users/173530/bookmarks/artworks/未分類?rest=hide ['173530', 'bookmarks/artworks/>
未分類', '未分類', None]` -> tag "未分類" included in "kind" field (i think this is undesired behavior)

After:
```
https://www.pixiv.net/en/users/173530/bookmarks/artworks ['173530', 'bookmarks/artworks', None, None]
https://www.pixiv.net/bookmark.php?id=173530 [None, None, None, 'id=173530']
No match: https://www.pixiv.net/en/users/3137110
https://www.pixiv.net/bookmark.php?id=3137110&tag=%E3%81%AF%E3%82%93%E3%82%82%E3%82%93&p=1 [None, None, None,
'id=3137110&tag=%E3%81%AF%E3%82%93%E3%82%82%E3%82%93&p=1']
https://www.pixiv.net/bookmark.php [None, None, None, None]
https://www.pixiv.net/bookmark.php?tag=foobar [None, None, None, 'tag=foobar']
https://www.pixiv.net/en/users/173530/following ['173530', 'following', None, None]
https://www.pixiv.net/bookmark.php?id=173530&type=user [None, None, None, 'id=173530&type=user']
https://touch.pixiv.net/bookmark.php?id=173530 [None, None, None, 'id=173530']
https://touch.pixiv.net/bookmark.php [None, None, None, None]
https://www.pixiv.net/en/users/173530/bookmarks/artworks?rest=hide ['173530', 'bookmarks/artworks', None,
'rest=hide']
https://www.pixiv.net/en/users/173530/bookmarks/artworks/未分類?rest=hide ['173530', 'bookmarks/artworks',
 '未分類', 'rest=hide']
```
