### PR TITLE
[aryion] Unescape paths too

### DIFF
--- a/gallery_dl/extractor/aryion.py
+++ b/gallery_dl/extractor/aryion.py
@@ -126,7 +126,8 @@ class AryionExtractor(Extractor):
             "user"  : self.user or artist,
             "title" : title,
             "artist": artist,
-            "path"  : text.split_html(extr("cookiecrumb'>", '</span'))[4:-1:2],
+            "path"  : text.split_html(text.unescape(extr(
+                "cookiecrumb'>", '</span')))[4:-1:2],
             "date"  : extr("class='pretty-date' title='", "'"),
             "size"  : text.parse_int(clen),
             "views" : text.parse_int(extr("Views</b>:", "<").replace(",", "")),


### PR DESCRIPTION
Without this you'll get paths like this:
  - Starcross - Ch. 2 &quot;The Ins and Outs of Sarah&quot;

This commit changes it to:
  - Starcross - Ch. 2 "The Ins and Outs of Sarah"

EDIT: haha nice, github auto-unescapes it, check message source for clarity ;)