### PR TITLE
[webtoons]: Add cookie rstagGDPR_DE=true

### DIFF
--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -25,6 +25,7 @@ class WebtoonsExtractor(Extractor):
             match.groups()
         cookies = self.session.cookies
         cookies.set("pagGDPR", "true", domain=self.cookiedomain)
+        cookies.set("rstagGDPR_DE", "true", domain=self.cookiedomain)
         cookies.set("ageGatePass", "true", domain=self.cookiedomain)
 
     def request(self, url, **kwargs):


### PR DESCRIPTION
Fixes #1430 for me in Germany

I'm not sure if users in other GDPR countries (countries within the European Union) need localised cookies for this to work, nor do I know if this breaks downloads for people outside the EU.