### PR TITLE
[gelbooru] fix tag category extraction

### DIFF
--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -91,6 +91,17 @@ class GelbooruPostExtractor(GelbooruBase,
             "content": "5e255713cbf0a8e0801dc423563c34d896bb9229",
             "count": 1,
         }),
+        ("https://gelbooru.com/index.php?page=post&s=view&id=6018318", {
+            "options": (("tags", True),),
+            "content": "977caf22f27c72a5d07ea4d4d9719acdab810991",
+            "keyword": {
+                "tags_artist": "kirisaki_shuusei",
+                "tags_character": str,
+                "tags_copyright": "vocaloid",
+                "tags_general": str,
+                "tags_metadata": str,
+            },
+        }),
         # video
         ("https://gelbooru.com/index.php?page=post&s=view&id=5938076", {
             "content": "6360452fa8c2f0c1137749e81471238564df832a",

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -47,6 +47,8 @@ class GelbooruV02Extractor(booru.BooruExtractor):
                 self.root, post["id"])
             page = self.request(url).text
         html = text.extract(page, '<ul id="tag-', '</ul>')[0]
+        if not html:
+            html = text.extract(page, '<ul class="tag-', '</ul>')[0]
         if html:
             tags = collections.defaultdict(list)
             pattern = re.compile(


### PR DESCRIPTION
extracting tag categories is currently broken on gelbooru (but not on other gelbooru-based sites) 
this fixes extraction and adds a test case