### PR TITLE
[booru] add an option to extract notes (only gelbooru for now)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1747,6 +1747,16 @@ Description
 
     Note: This requires 1 additional HTTP request for each post.
 
+extractor.[booru].notes
+----------------------
+Type
+    ``bool``
+Default
+    ``false``
+Description
+    Extract overlay notes (position and text).
+
+    Note: This requires 1 additional HTTP request for each post.
 
 extractor.[manga-extractor].chapter-reverse
 -------------------------------------------

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -279,7 +279,8 @@
         },
         "booru":
         {
-            "tags": false
+            "tags": false,
+            "notes": false
         }
     },
 

--- a/gallery_dl/extractor/booru.py
+++ b/gallery_dl/extractor/booru.py
@@ -24,6 +24,7 @@ class BooruExtractor(BaseExtractor):
         self.login()
         data = self.metadata()
         tags = self.config("tags", False)
+        notes = self.config("notes", False)
 
         for post in self.posts():
             try:
@@ -35,8 +36,11 @@ class BooruExtractor(BaseExtractor):
                                "(md5: %s)", post.get("id"), post.get("md5"))
                 continue
 
+            page_html = None
             if tags:
-                self._extended_tags(post)
+                page_html = self._extended_tags(post)
+            if notes:
+                self._notes(post, page_html)
             self._prepare(post)
             post.update(data)
             text.nameext_from_url(url, post)
@@ -67,3 +71,6 @@ class BooruExtractor(BaseExtractor):
 
     def _extended_tags(self, post, page=None):
         """Generate extended tag information"""
+
+    def _notes(self, post, page=None):
+        """Generate information about notes"""

--- a/gallery_dl/extractor/booru.py
+++ b/gallery_dl/extractor/booru.py
@@ -70,7 +70,13 @@ class BooruExtractor(BaseExtractor):
         """Prepare the 'post's metadata"""
 
     def _extended_tags(self, post, page=None):
-        """Generate extended tag information"""
+        """Generate extended tag information
+
+        The return value of this function will be
+        passed to the _notes function as the page parameter.
+        This makes it possible to reuse the same HTML both for
+        extracting tags and notes.
+        """
 
     def _notes(self, post, page=None):
         """Generate information about notes"""

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -112,20 +112,22 @@ class GelbooruPostExtractor(GelbooruBase,
         ("https://gelbooru.com/index.php?page=post&s=view&id=5997331", {
             "options": (("notes", True),),
             "keywords": {
-                "notes": [{
-                    "height": 553,
-                    "text": "Look over this way when you talk~",
-                    "width": 246,
-                    "x": 35,
-                    "y": 72
-                },
-                {
-                    "height": 557,
-                    "text": "Hey~\nAre you listening~?",
-                    "width": 246,
-                    "x": 1233,
-                    "y": 109
-                }]
+                "notes": [
+                    {
+                        "height": 553,
+                        "text": "Look over this way when you talk~",
+                        "width": 246,
+                        "x": 35,
+                        "y": 72
+                    },
+                    {
+                        "height": 557,
+                        "text": "Hey~\nAre you listening~?",
+                        "width": 246,
+                        "x": 1233,
+                        "y": 109
+                    }
+                ]
             }
         }),
     )

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -115,14 +115,14 @@ class GelbooruPostExtractor(GelbooruBase,
                 "notes": [
                     {
                         "height": 553,
-                        "text": "Look over this way when you talk~",
+                        "body": "Look over this way when you talk~",
                         "width": 246,
                         "x": 35,
                         "y": 72
                     },
                     {
                         "height": 557,
-                        "text": "Hey~\nAre you listening~?",
+                        "body": "Hey~\nAre you listening~?",
                         "width": 246,
                         "x": 1233,
                         "y": 109

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -108,4 +108,24 @@ class GelbooruPostExtractor(GelbooruBase,
             "pattern": r"https://img\d\.gelbooru\.com/images"
                        r"/22/61/226111273615049235b001b381707bd0\.webm",
         }),
+        # notes
+        ("https://gelbooru.com/index.php?page=post&s=view&id=5997331", {
+            "options": (("notes", True),),
+            "keywords": {
+                "notes": [{
+                    "height": 553,
+                    "text": "Look over this way when you talk~",
+                    "width": 246,
+                    "x": 35,
+                    "y": 72
+                },
+                {
+                    "height": 557,
+                    "text": "Hey~\nAre you listening~?",
+                    "width": 246,
+                    "x": 1233,
+                    "y": 109
+                }]
+            }
+        }),
     )

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -69,13 +69,15 @@ class GelbooruV02Extractor(booru.BooruExtractor):
         if not notes_data:
             return
 
-        for note_data in text.extract_iter(notes_data, '<article', '</article>'):
+        note_iter = text.extract_iter(notes_data, '<article', '</article>')
+        extr = text.extract
+        for note_data in note_iter:
             note = {
-                "width": int(text.extract(note_data, 'data-width="', '"')[0]),
-                "height": int(text.extract(note_data, 'data-height="', '"')[0]),
-                "x": int(text.extract(note_data, 'data-x="', '"')[0]),
-                "y": int(text.extract(note_data, 'data-y="', '"')[0]),
-                "text": text.extract(note_data, 'data-body="', '"')[0],
+                "width": int(extr(note_data, 'data-width="', '"')[0]),
+                "height": int(extr(note_data, 'data-height="', '"')[0]),
+                "x": int(extr(note_data, 'data-x="', '"')[0]),
+                "y": int(extr(note_data, 'data-y="', '"')[0]),
+                "text": extr(note_data, 'data-body="', '"')[0],
             }
             notes.append(note)
 

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -57,6 +57,29 @@ class GelbooruV02Extractor(booru.BooruExtractor):
                 tags[tag_type].append(text.unquote(tag_name))
             for key, value in tags.items():
                 post["tags_" + key] = " ".join(value)
+        return page
+
+    def _notes(self, post, page=None):
+        if not page:
+            url = "{}/index.php?page=post&s=view&id={}".format(
+                self.root, post["id"])
+            page = self.request(url).text
+        notes = []
+        notes_data = text.extract(page, '<section id="notes"', '</section>')[0]
+        if not notes_data:
+            return
+
+        for note_data in text.extract_iter(notes_data, '<article', '</article>'):
+            note = {
+                "width": int(text.extract(note_data, 'data-width="', '"')[0]),
+                "height": int(text.extract(note_data, 'data-height="', '"')[0]),
+                "x": int(text.extract(note_data, 'data-x="', '"')[0]),
+                "y": int(text.extract(note_data, 'data-y="', '"')[0]),
+                "text": text.extract(note_data, 'data-body="', '"')[0],
+            }
+            notes.append(note)
+
+        post["notes"] = notes
 
 
 BASE_PATTERN = GelbooruV02Extractor.update({

--- a/gallery_dl/extractor/gelbooru_v02.py
+++ b/gallery_dl/extractor/gelbooru_v02.py
@@ -77,7 +77,7 @@ class GelbooruV02Extractor(booru.BooruExtractor):
                 "height": int(extr(note_data, 'data-height="', '"')[0]),
                 "x": int(extr(note_data, 'data-x="', '"')[0]),
                 "y": int(extr(note_data, 'data-y="', '"')[0]),
-                "text": extr(note_data, 'data-body="', '"')[0],
+                "body": extr(note_data, 'data-body="', '"')[0],
             }
             notes.append(note)
 


### PR DESCRIPTION
This PR adds an option to the booru extractors to extract the position and content of overlay notes:
![image](https://user-images.githubusercontent.com/67429906/114282760-3b682000-9a46-11eb-8166-831d562c2446.png)
I only implemented it for gelbooru for the time being, but it shouldn't be too hard to do other sites later.
