### PR TITLE
[danbooru] add option for extended metadata extraction

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -726,6 +726,17 @@ Description
     * ``true``: Original ZIP archives
     * ``false``: Converted video files
 
+extractor.danbooru.extended-metadata
+-------------------------
+Type
+    ``bool``
+Default
+    ``false``
+Description
+    If enabled, additional metadata (notes, artist commentary, parent, children)
+    will extracted.
+
+    Note: This requires 1 additional HTTP request for each post.
 
 extractor.derpibooru.api-key
 ----------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -733,8 +733,7 @@ Type
 Default
     ``false``
 Description
-    If enabled, additional metadata (notes, artist commentary, parent, children)
-    will extracted.
+    Extract additional metadata (notes, artist commentary, parent, children)
 
     Note: This requires 1 additional HTTP request for each post.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -726,8 +726,8 @@ Description
     * ``true``: Original ZIP archives
     * ``false``: Converted video files
 
-extractor.danbooru.extended-metadata
--------------------------
+extractor.danbooru.metadata
+---------------------------
 Type
     ``bool``
 Default

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -49,7 +49,8 @@
         {
             "username": null,
             "password": null,
-            "ugoira": false
+            "ugoira": false,
+            "extended-metadata": false
         },
         "derpibooru":
         {

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -50,7 +50,7 @@
             "username": null,
             "password": null,
             "ugoira": false,
-            "extended-metadata": false
+            "metadata": false
         },
         "derpibooru":
         {

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -66,9 +66,12 @@ class DanbooruExtractor(Extractor):
                     post["extension"] = "webm"
 
             if self.extended_metadata:
-                post.update(self.request(
-                    "{}/posts/{}.json?only=artist_commentary,children,notes,parent".format(
-                        self.root, post["id"])).json())
+                template = (
+                    "{}/posts/{}.json"
+                    "?only=artist_commentary,children,notes,parent"
+                )
+                resp = self.request(template.format(self.root, post["id"]))
+                post.update(resp.json())
 
             post.update(data)
             yield Message.Directory, post

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -32,7 +32,7 @@ class DanbooruExtractor(Extractor):
         super().__init__(match)
         self.root = "https://{}.donmai.us".format(match.group(1))
         self.ugoira = self.config("ugoira", False)
-        self.extended_metadata = self.config("extended-metadata", False)
+        self.extended_metadata = self.config("metadata", False)
 
         username, api_key = self._get_auth_info()
         if username:

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -32,6 +32,7 @@ class DanbooruExtractor(Extractor):
         super().__init__(match)
         self.root = "https://{}.donmai.us".format(match.group(1))
         self.ugoira = self.config("ugoira", False)
+        self.extended_metadata = self.config("extended-metadata", False)
 
         username, api_key = self._get_auth_info()
         if username:
@@ -63,6 +64,11 @@ class DanbooruExtractor(Extractor):
                 else:
                     url = post["large_file_url"]
                     post["extension"] = "webm"
+
+            if self.extended_metadata:
+                post.update(self.request(
+                    "{}/posts/{}.json?only=artist_commentary,children,notes,parent".format(
+                        self.root, post["id"])).json())
 
             post.update(data)
             yield Message.Directory, post


### PR DESCRIPTION
This PR adds an option to danbooru to get additional metadata about notes, artist commentary, parent and children at the cost of one additional API request.