### PR TITLE
add extractors for fantia and fanbox

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -947,21 +947,20 @@ Description
     Download full-sized original images if available.
 
 
-extractor.fanbox.videos
+extractor.fanbox.embeds
 -----------------------
 Type
     ``bool`` or ``string``
 Default
     ``true``
 Description
-    Control behavior on videos embedded from external sites.
-    Recognizes embeds from YouTube, Vimeo and SoundCloud.
+    Control behavior on embedded content from external sites.
 
-    * ``true``: Extract video URLs (videos are not downloaded, as
-      galley-dl does not support these sites natively)
-    * ``"ytdl"``: Download videos and let `youtube-dl`_ handle all of
-      video extraction and download
-    * ``false``: Ignore videos
+    * ``true``: Extract embed URLs and download them if supported
+      (videos are not downloaded).
+    * ``"ytdl"``: Like ``true``, but let `youtube-dl`_ handle video
+      extraction and download for YouTube, Vimeo and SoundCloud embeds.
+    * ``false``: Ignore embeds.
 
 
 extractor.flickr.access-token & .access-token-secret

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -947,6 +947,23 @@ Description
     Download full-sized original images if available.
 
 
+extractor.fanbox.videos
+-----------------------
+Type
+    ``bool`` or ``string``
+Default
+    ``true``
+Description
+    Control behavior on videos embedded from external sites.
+    Recognizes embeds from YouTube, Vimeo and SoundCloud.
+
+    * ``true``: Extract video URLs (videos are not downloaded, as
+      galley-dl does not support these sites natively)
+    * ``"ytdl"``: Download videos and let `youtube-dl`_ handle all of
+      video extraction and download
+    * ``false``: Ignore videos
+
+
 extractor.flickr.access-token & .access-token-secret
 ----------------------------------------------------
 Type

--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -152,6 +152,18 @@ Consider all sites to be NSFW unless otherwise known.
     <td></td>
 </tr>
 <tr>
+    <td>Fanbox</td>
+    <td>https://www.fanbox.cc/</td>
+    <td>Creators, Posts</td>
+    <td><a href="https://github.com/mikf/gallery-dl#cookies">Cookies</a></td>
+</tr>
+<tr>
+    <td>Fantia</td>
+    <td>https://fantia.jp/</td>
+    <td>Creators, Posts</td>
+    <td><a href="https://github.com/mikf/gallery-dl#cookies">Cookies</a></td>
+</tr>
+<tr>
     <td>Flickr</td>
     <td>https://www.flickr.com/</td>
     <td>Albums, Favorites, Galleries, Groups, individual Images, Search Results, User Profiles</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -31,6 +31,8 @@ modules = [
     "erome",
     "exhentai",
     "fallenangels",
+    "fanbox",
+    "fantia",
     "flickr",
     "furaffinity",
     "fuskator",

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -77,8 +77,11 @@ class FanboxExtractor(Extractor):
             num += 1
             yield Message.Url, cover_image, final_post
 
+        if not content_body:
+            return
+
         for group in ("images", "imageMap"):
-            if group in (content_body or []):
+            if group in content_body:
                 for item in content_body[group]:
                     final_post = post.copy()
                     final_post["fileUrl"] = item["originalUrl"]
@@ -93,7 +96,7 @@ class FanboxExtractor(Extractor):
                     yield Message.Url, item["originalUrl"], final_post
 
         for group in ("files", "fileMap"):
-            if group in (content_body or []):
+            if group in content_body:
                 for item in content_body[group]:
                     final_post = post.copy()
                     final_post["fileUrl"] = item["url"]

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://www.fanbox.cc/"""
+
+from .common import Extractor, Message
+from .. import text, exception
+from ..cache import memcache
+import collections
+import itertools
+import json
+
+
+class FanboxExtractor(Extractor):
+    """Base class for fanbox extractors"""
+    category = "fanbox"
+    root = "https://www.fanbox.cc"
+    directory_fmt = ("{category}", "{creator_id}")
+    filename_fmt = "{id}_{num}.{extension}"
+    archive_fmt = "{id}_{num}"
+    _warning = True
+
+    def items(self):
+        yield Message.Version, 1
+
+        if self._warning:
+            if "FANBOXSESSID" not in self.session.cookies:
+                self.log.warning("no 'FANBOXSESSID' cookie set")
+            FanboxExtractor._warning = False
+
+        for url, data in self.posts():
+            yield Message.Directory, data
+            yield Message.Url, url, data
+
+    def posts(self):
+        """Return all relevant post objects"""
+
+    def _pagination(self, url):
+        headers = {"Origin": self.root}
+
+        while url:
+            url = text.ensure_http_scheme(url)
+            body = self.request(url, headers=headers).json()["body"]
+            for item in body["items"]:
+                for url, data in self._get_post_data_and_urls(item["id"]):
+                    yield url, data
+
+            url = body["nextUrl"]
+
+    def _get_post_data_and_urls(self, post_id):
+        """Fetch and process post data"""
+        headers = {"Origin": self.root}
+        url = "https://api.fanbox.cc/post.info?postId="+post_id
+        pbody = self.request(url, headers=headers).json()["body"]
+
+        post = {
+            "id": pbody["id"],
+            "title": pbody["title"],
+            "fee_required": pbody["feeRequired"],
+            "published": pbody["publishedDatetime"],
+            "updated": pbody["updatedDatetime"],
+            "type": pbody["type"],
+            "tags": pbody["tags"],
+            "creator_id": pbody["creatorId"],
+            "has_adult_content": pbody["hasAdultContent"],
+            "post_url": self.root+"/@"+pbody["creatorId"]+"/posts/"+post_id,
+            "creator_user_id": pbody["user"]["userId"],
+            "creator_name": pbody["user"]["name"],
+            "text": pbody["body"].get("text", None) if pbody["body"] else None,
+            "is_cover_image": False
+        }
+
+        num = 0
+        if "coverImageUrl" in pbody and pbody["coverImageUrl"]:
+            final_post = dict(post)
+            final_post["isCoverImage"] = True
+            final_post["file_url"] = pbody["coverImageUrl"]
+            final_post = text.nameext_from_url(pbody["coverImageUrl"], final_post)
+            final_post["num"] = num
+            num += 1
+            yield pbody["coverImageUrl"], final_post
+
+        for group in ["images", "imageMap"]:
+            if group in (pbody["body"] or []):
+                for item in pbody["body"][group]:
+                    final_post = dict(post)
+                    final_post["file_url"] = item["originalUrl"]
+                    final_post = text.nameext_from_url(item["originalUrl"], final_post)
+                    if "extension" in item:
+                        final_post["extension"] = item["extension"]
+                    final_post["file_id"] = item.get("id", None)
+                    final_post["width"] = item.get("width", None)
+                    final_post["height"] = item.get("height", None)
+                    final_post["num"] = num
+                    num += 1
+                    yield item["originalUrl"], final_post
+
+        for group in ["files", "fileMap"]:
+            if group in (pbody["body"] or []):
+                for item in pbody["body"][group]:
+                    final_post = dict(post)
+                    final_post["file_url"] = item["url"]
+                    final_post = text.nameext_from_url(item["url"], final_post)
+                    if "extension" in item:
+                        final_post["extension"] = item["extension"]
+                    if "name" in item:
+                        final_post["filename"] = item["name"]
+                    final_post["file_id"] = item.get("id", None)
+                    final_post["num"] = num
+                    num += 1
+                    yield item["url"], final_post
+
+class FanboxCreatorExtractor(FanboxExtractor):
+    """Extractor for a creator's works"""
+    subcategory = "creator"
+    pattern = r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$"
+    test = (
+        ("https://xub.fanbox.cc", {
+            "range": "1-15",
+            "count": ">= 15",
+            "keyword": {
+                "creator_id" : "xub",
+                "tags"       : list,
+                "title"      : str,
+            },
+        }),
+    )
+
+    def __init__(self, match):
+        FanboxExtractor.__init__(self, match)
+        self.creator_id = match.group(1) or match.group(2)
+
+    def posts(self):
+        url = "https://api.fanbox.cc/post.listCreator?creatorId=" + self.creator_id + "&limit=10"
+
+        return self._pagination(url)
+
+class FanboxPostExtractor(FanboxExtractor):
+    """Extractor for media from a single post"""
+    subcategory = "post"
+    pattern = r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)"
+    test = (
+        ("https://www.fanbox.cc/@xub/posts/1910054", {
+            "count": 3,
+            "keyword": {
+                "title": "えま★おうがすと",
+                "tags": list,
+                "has_adult_content": True,
+                "is_cover_image": False
+            },
+        }),
+    )
+
+    def __init__(self, match):
+        FanboxExtractor.__init__(self, match)
+        self.post_id = match.group(1) or match.group(2)
+
+    def posts(self):
+        return self._get_post_data_and_urls(self.post_id)

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -7,11 +7,7 @@
 """Extractors for https://www.fanbox.cc/"""
 
 from .common import Extractor, Message
-from .. import text, exception
-from ..cache import memcache
-import collections
-import itertools
-import json
+from .. import text
 
 
 class FanboxExtractor(Extractor):
@@ -78,7 +74,9 @@ class FanboxExtractor(Extractor):
             final_post = dict(post)
             final_post["isCoverImage"] = True
             final_post["file_url"] = pbody["coverImageUrl"]
-            final_post = text.nameext_from_url(pbody["coverImageUrl"], final_post)
+            final_post = text.nameext_from_url(
+                pbody["coverImageUrl"], final_post
+            )
             final_post["num"] = num
             num += 1
             yield pbody["coverImageUrl"], final_post
@@ -88,7 +86,9 @@ class FanboxExtractor(Extractor):
                 for item in pbody["body"][group]:
                     final_post = dict(post)
                     final_post["file_url"] = item["originalUrl"]
-                    final_post = text.nameext_from_url(item["originalUrl"], final_post)
+                    final_post = text.nameext_from_url(
+                        item["originalUrl"], final_post
+                    )
                     if "extension" in item:
                         final_post["extension"] = item["extension"]
                     final_post["file_id"] = item.get("id", None)
@@ -113,10 +113,12 @@ class FanboxExtractor(Extractor):
                     num += 1
                     yield item["url"], final_post
 
+
 class FanboxCreatorExtractor(FanboxExtractor):
     """Extractor for a creator's works"""
     subcategory = "creator"
-    pattern = r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$"
+    pattern = (r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|"
+               r"(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$")
     test = (
         ("https://xub.fanbox.cc", {
             "range": "1-15",
@@ -134,14 +136,16 @@ class FanboxCreatorExtractor(FanboxExtractor):
         self.creator_id = match.group(1) or match.group(2)
 
     def posts(self):
-        url = "https://api.fanbox.cc/post.listCreator?creatorId=" + self.creator_id + "&limit=10"
+        url = "https://api.fanbox.cc/post.listCreator?creatorId={}&limit=10"
 
-        return self._pagination(url)
+        return self._pagination(url.format(self._creator_id))
+
 
 class FanboxPostExtractor(FanboxExtractor):
     """Extractor for media from a single post"""
     subcategory = "post"
-    pattern = r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)"
+    pattern = (r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|"
+               r"(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)")
     test = (
         ("https://www.fanbox.cc/@xub/posts/1910054", {
             "count": 3,

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -11,7 +11,7 @@ from .. import text
 
 
 class FanboxExtractor(Extractor):
-    """Base class for fanbox extractors"""
+    """Base class for Fanbox extractors"""
     category = "fanbox"
     root = "https://www.fanbox.cc"
     directory_fmt = ("{category}", "{creator_id}")
@@ -115,7 +115,7 @@ class FanboxExtractor(Extractor):
 
 
 class FanboxCreatorExtractor(FanboxExtractor):
-    """Extractor for a fanbox creator's works"""
+    """Extractor for a Fanbox creator's works"""
     subcategory = "creator"
     pattern = (r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|"
                r"(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$")
@@ -142,7 +142,7 @@ class FanboxCreatorExtractor(FanboxExtractor):
 
 
 class FanboxPostExtractor(FanboxExtractor):
-    """Extractor for media from a single fanbox post"""
+    """Extractor for media from a single Fanbox post"""
     subcategory = "post"
     pattern = (r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|"
                r"(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)")

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -115,7 +115,7 @@ class FanboxExtractor(Extractor):
 
 
 class FanboxCreatorExtractor(FanboxExtractor):
-    """Extractor for a creator's works"""
+    """Extractor for a fanbox creator's works"""
     subcategory = "creator"
     pattern = (r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|"
                r"(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$")
@@ -142,7 +142,7 @@ class FanboxCreatorExtractor(FanboxExtractor):
 
 
 class FanboxPostExtractor(FanboxExtractor):
-    """Extractor for media from a single post"""
+    """Extractor for media from a single fanbox post"""
     subcategory = "post"
     pattern = (r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|"
                r"(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)")

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -11,8 +11,9 @@ from .. import text
 
 
 BASE_PATTERN = (
-    r"(?:https?://)?(?:([a-zA-Z0-9_-]+)\.fanbox\.cc|"
-    r"(?:www\.)?fanbox\.cc/@([^/?#]+))"
+    r"(?:https?://)?(?:"
+    r"(?!www\.)([\w-]+)\.fanbox\.cc|"
+    r"(?:www\.)?fanbox\.cc/@([\w-]+))"
 )
 
 

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -10,6 +10,12 @@ from .common import Extractor, Message
 from .. import text
 
 
+BASE_PATTERN = (
+    r"(?:https?://)?(?:([a-zA-Z0-9_-]+)\.fanbox\.cc|"
+    r"(?:www\.)?fanbox\.cc/@([^/?#]+))"
+)
+
+
 class FanboxExtractor(Extractor):
     """Base class for Fanbox extractors"""
     category = "fanbox"
@@ -117,8 +123,7 @@ class FanboxExtractor(Extractor):
 class FanboxCreatorExtractor(FanboxExtractor):
     """Extractor for a Fanbox creator's works"""
     subcategory = "creator"
-    pattern = (r"(?:https?://)?([a-zA-Z0-9_-]+)\.fanbox\.cc/?$|"
-               r"(?:https?://)?(?:www\.)?fanbox\.cc/@([^/?#]+)/?$")
+    pattern = BASE_PATTERN + r"/?$"
     test = (
         ("https://xub.fanbox.cc", {
             "range": "1-15",
@@ -144,8 +149,7 @@ class FanboxCreatorExtractor(FanboxExtractor):
 class FanboxPostExtractor(FanboxExtractor):
     """Extractor for media from a single Fanbox post"""
     subcategory = "post"
-    pattern = (r"(?:https?://)?(?:www\.)?fanbox\.cc/@[^/?#]+/posts/([^/?#]+)|"
-               r"(?:https?://)?[a-zA-Z0-9_-]+\.fanbox\.cc/posts/([^/?#]+)")
+    pattern = BASE_PATTERN + r"/posts/(\d+)"
     test = (
         ("https://www.fanbox.cc/@xub/posts/1910054", {
             "count": 3,
@@ -160,7 +164,7 @@ class FanboxPostExtractor(FanboxExtractor):
 
     def __init__(self, match):
         FanboxExtractor.__init__(self, match)
-        self.post_id = match.group(1) or match.group(2)
+        self.post_id = match.group(3)
 
     def posts(self):
         return self._get_post_data_and_urls(self.post_id)

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -48,16 +48,19 @@ class FanboxExtractor(Extractor):
             url = text.ensure_http_scheme(url)
             body = self.request(url, headers=headers).json()["body"]
             for item in body["items"]:
-                yield self._get_post_data(item["id"])
+                yield self._process_post(item)
 
             url = body["nextUrl"]
 
-    def _get_post_data(self, post_id):
+    def _get_post_data_from_id(self, post_id):
         """Fetch and process post data"""
         headers = {"Origin": self.root}
         url = "https://api.fanbox.cc/post.info?postId="+post_id
         post = self.request(url, headers=headers).json()["body"]
 
+        return self._process_post(post)
+
+    def _process_post(self, post):
         content_body = post.pop("body", None)
         post["date"] = text.parse_datetime(post["publishedDatetime"])
         post["text"] = content_body.get("text") if content_body else None
@@ -161,4 +164,4 @@ class FanboxPostExtractor(FanboxExtractor):
         self.post_id = match.group(3)
 
     def posts(self):
-        yield self._get_post_data(self.post_id)
+        (self._get_post_data_from_id(self.post_id),)

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -111,7 +111,7 @@ class FanboxExtractor(Extractor):
 class FanboxCreatorExtractor(FanboxExtractor):
     """Extractor for a Fanbox creator's works"""
     subcategory = "creator"
-    pattern = BASE_PATTERN + r"/?$"
+    pattern = BASE_PATTERN + r"(?:/posts)?/?$"
     test = (
         ("https://xub.fanbox.cc", {
             "range": "1-15",

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -122,6 +122,9 @@ class FanboxCreatorExtractor(FanboxExtractor):
                 "title"      : str,
             },
         }),
+        ("https://xub.fanbox.cc/posts"),
+        ("https://www.fanbox.cc/@xub/"),
+        ("https://www.fanbox.cc/@xub/posts"),
     )
 
     def __init__(self, match):

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -27,6 +27,7 @@ class FanboxExtractor(Extractor):
     _warning = True
 
     def __init__(self, match):
+        Extractor.__init__(self, match)
         self.videos = self.config("videos", True)
 
     def items(self):
@@ -89,7 +90,6 @@ class FanboxExtractor(Extractor):
         if self.videos and "video" in content_body:
             provider = content_body["video"]["serviceProvider"]
             video_id = content_body["video"]["videoId"]
-            final_post["video"] = content_body["video"]
             prefix = "ytdl:" if self.videos == "ytdl" else ""
             final_url = None
 
@@ -103,7 +103,11 @@ class FanboxExtractor(Extractor):
                 self.log.warning("service not recognized: {}".format(provider))
 
             if final_url:
-                yield Message.Url, final_url, final_post
+                final_post = post.copy()
+                final_post["video"] = content_body["video"]
+                final_post["num"] = num
+                num += 1
+                yield Message.Queue, final_url, final_post
 
         for group in ("images", "imageMap"):
             if group in content_body:
@@ -186,4 +190,4 @@ class FanboxPostExtractor(FanboxExtractor):
         self.post_id = match.group(3)
 
     def posts(self):
-        (self._get_post_data_from_id(self.post_id),)
+        return (self._get_post_data_from_id(self.post_id),)

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -28,7 +28,7 @@ class FanboxExtractor(Extractor):
 
     def __init__(self, match):
         Extractor.__init__(self, match)
-        self.videos = self.config("videos", True)
+        self.embeds = self.config("embeds", True)
 
     def items(self):
         yield Message.Version, 1
@@ -66,6 +66,12 @@ class FanboxExtractor(Extractor):
 
     def _process_post(self, post):
         content_body = post.pop("body", None)
+        if content_body:
+            if "html" in content_body:
+                post["html"] = content_body["html"]
+            if post["type"] == "article":
+                post["articleBody"] = content_body.copy()
+
         post["date"] = text.parse_datetime(post["publishedDatetime"])
         post["text"] = content_body.get("text") if content_body else None
         post["isCoverImage"] = False
@@ -87,31 +93,33 @@ class FanboxExtractor(Extractor):
         if not content_body:
             return
 
-        if self.videos and "video" in content_body:
-            provider = content_body["video"]["serviceProvider"]
-            video_id = content_body["video"]["videoId"]
-            prefix = "ytdl:" if self.videos == "ytdl" else ""
-            final_url = None
+        if "html" in content_body:
+            html_urls = []
 
-            if provider == "soundcloud":
-                final_url = prefix+"https://soundcloud.com/"+video_id
-            elif provider == "youtube":
-                final_url = prefix+"https://youtube.com/watch?v="+video_id
-            elif provider == "vimeo":
-                final_url = prefix+"https://vimeo.com/"+video_id
-            else:
-                self.log.warning("service not recognized: {}".format(provider))
+            for href in text.extract_iter(content_body["html"], 'href="', '"'):
+                if "fanbox.pixiv.net/images/entry" in href:
+                    html_urls.append(href)
+                elif "downloads.fanbox.cc" in href:
+                    html_urls.append(href)
+            for src in text.extract_iter(content_body["html"],
+                                         'data-src-original="', '"'):
+                html_urls.append(src)
 
-            if final_url:
+            for url in html_urls:
                 final_post = post.copy()
-                final_post["video"] = content_body["video"]
+                text.nameext_from_url(url, final_post)
+                final_post["fileUrl"] = url
                 final_post["num"] = num
                 num += 1
-                yield Message.Queue, final_url, final_post
+                yield Message.Url, url, final_post
 
         for group in ("images", "imageMap"):
             if group in content_body:
                 for item in content_body[group]:
+                    if group == "imageMap":
+                        # imageMap is a dict with image objects as values
+                        item = content_body[group][item]
+
                     final_post = post.copy()
                     final_post["fileUrl"] = item["originalUrl"]
                     text.nameext_from_url(item["originalUrl"], final_post)
@@ -127,6 +135,10 @@ class FanboxExtractor(Extractor):
         for group in ("files", "fileMap"):
             if group in content_body:
                 for item in content_body[group]:
+                    if group == "fileMap":
+                        # fileMap is a dict with file objects as values
+                        item = content_body[group][item]
+
                     final_post = post.copy()
                     final_post["fileUrl"] = item["url"]
                     text.nameext_from_url(item["url"], final_post)
@@ -138,6 +150,62 @@ class FanboxExtractor(Extractor):
                     final_post["num"] = num
                     num += 1
                     yield Message.Url, item["url"], final_post
+
+        if self.embeds:
+            embeds_found = []
+            if "video" in content_body:
+                embeds_found.append(content_body["video"])
+            embeds_found.extend(content_body.get("embedMap", {}).values())
+
+            for embed in embeds_found:
+                # embed_result is (message type, url, metadata dict)
+                embed_result = self._process_embed(post, embed)
+                if not embed_result:
+                    continue
+                embed_result[2]["num"] = num
+                num += 1
+                yield embed_result
+
+    def _process_embed(self, post, embed):
+        provider = embed["serviceProvider"]
+        content_id = embed.get("videoId") or embed.get("contentId")
+        prefix = "ytdl:" if self.embeds == "ytdl" else ""
+        url = None
+        is_video = False
+
+        if provider == "soundcloud":
+            url = prefix+"https://soundcloud.com/"+content_id
+            is_video = True
+        elif provider == "youtube":
+            url = prefix+"https://youtube.com/watch?v="+content_id
+            is_video = True
+        elif provider == "vimeo":
+            url = prefix+"https://vimeo.com/"+content_id
+            is_video = True
+        elif provider == "fanbox":
+            # this is an old URL format that redirects
+            # to a proper Fanbox URL
+            url = "https://www.pixiv.net/fanbox/"+content_id
+            # resolve redirect
+            response = self.request(url, method="HEAD", allow_redirects=False)
+            url = response.headers["Location"]
+        elif provider == "twitter":
+            url = "https://twitter.com/_/status/"+content_id
+        elif provider == "google_forms":
+            templ = "https://docs.google.com/forms/d/e/{}/viewform?usp=sf_link"
+            url = templ.format(content_id)
+        else:
+            self.log.warning("service not recognized: {}".format(provider))
+
+        if url:
+            final_post = post.copy()
+            final_post["embed"] = embed
+            final_post["embedUrl"] = url
+            text.nameext_from_url(url, final_post)
+            msg_type = Message.Queue
+            if is_video and self.embeds == "ytdl":
+                msg_type = Message.Url
+            return msg_type, url, final_post
 
 
 class FanboxCreatorExtractor(FanboxExtractor):
@@ -181,6 +249,27 @@ class FanboxPostExtractor(FanboxExtractor):
                 "tags": list,
                 "hasAdultContent": True,
                 "isCoverImage": False
+            },
+        }),
+        # entry post type, image embedded in html of the post
+        ("https://nekoworks.fanbox.cc/posts/915", {
+            "count": 2,
+            "keyword": {
+                "title": "【SAYORI FAN CLUB】お届け内容",
+                "tags": list,
+                "html": str,
+                "hasAdultContent": True
+            },
+        }),
+        # article post type, imageMap, 2 twitter embeds, fanbox embed
+        ("https://steelwire.fanbox.cc/posts/285502", {
+            "options": (("embeds", True),),
+            "count": 10,
+            "keyword": {
+                "title": "イラスト+SS｜義足の炭鉱少年が義足を見せてくれるだけ 【全体公開版】",
+                "tags": list,
+                "articleBody": dict,
+                "hasAdultContent": True
             },
         }),
     )

--- a/gallery_dl/extractor/fanbox.py
+++ b/gallery_dl/extractor/fanbox.py
@@ -167,6 +167,7 @@ class FanboxExtractor(Extractor):
                 yield embed_result
 
     def _process_embed(self, post, embed):
+        final_post = post.copy()
         provider = embed["serviceProvider"]
         content_id = embed.get("videoId") or embed.get("contentId")
         prefix = "ytdl:" if self.embeds == "ytdl" else ""
@@ -189,6 +190,7 @@ class FanboxExtractor(Extractor):
             # resolve redirect
             response = self.request(url, method="HEAD", allow_redirects=False)
             url = response.headers["Location"]
+            final_post["_extractor"] = FanboxPostExtractor
         elif provider == "twitter":
             url = "https://twitter.com/_/status/"+content_id
         elif provider == "google_forms":
@@ -198,7 +200,6 @@ class FanboxExtractor(Extractor):
             self.log.warning("service not recognized: {}".format(provider))
 
         if url:
-            final_post = post.copy()
             final_post["embed"] = embed
             final_post["embedUrl"] = url
             text.nameext_from_url(url, final_post)

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -101,7 +101,7 @@ class FantiaExtractor(Extractor):
 class FantiaCreatorExtractor(FantiaExtractor):
     """Extractor for a Fantia creator's works"""
     subcategory = "creator"
-    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/fanclubs/([^/?#]+)"
+    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/fanclubs/(\d+)"
     test = (
         ("https://fantia.jp/fanclubs/6939", {
             "range": "1-25",
@@ -127,7 +127,7 @@ class FantiaCreatorExtractor(FantiaExtractor):
 class FantiaPostExtractor(FantiaExtractor):
     """Extractor for media from a single Fantia post"""
     subcategory = "post"
-    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/posts/([^/?#]+)"
+    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/posts/(\d+)"
     test = (
         ("https://fantia.jp/posts/508363", {
             "count": 6,

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -105,7 +105,7 @@ class FantiaExtractor(Extractor):
 
 
 class FantiaCreatorExtractor(FantiaExtractor):
-    """Extractor for a creator's works"""
+    """Extractor for a fantia creator's works"""
     subcategory = "creator"
     pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/fanclubs/([^/?#]+)"
     test = (
@@ -131,7 +131,7 @@ class FantiaCreatorExtractor(FantiaExtractor):
 
 
 class FantiaPostExtractor(FantiaExtractor):
-    """Extractor for media from a single post"""
+    """Extractor for media from a single fantia post"""
     subcategory = "post"
     pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/posts/([^/?#]+)"
     test = (

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://fantia.jp/"""
+
+from .common import Extractor, Message
+from .. import text, exception
+from ..cache import memcache
+import collections
+import itertools
+import json
+
+
+class FantiaExtractor(Extractor):
+    """Base class for fantia extractors"""
+    category = "fantia"
+    root = "https://fantia.jp"
+    directory_fmt = ("{category}", "{fanclub_id}")
+    filename_fmt = "{post_id}_{file_id}.{extension}"
+    archive_fmt = "{post_id}_{file_id}"
+    _warning = True
+
+    def items(self):
+        yield Message.Version, 1
+
+        if self._warning:
+            if "_session_id" not in self.session.cookies:
+                self.log.warning("no '_session_id' cookie set")
+            FantiaExtractor._warning = False
+
+        for url, data in self.posts():
+            if data["content_filename"]:
+                data["filename"] = data["content_filename"]
+                if "." in data["filename"]:
+                    data["extension"] = data["filename"][data["filename"].rfind(".")+1:]
+                else:
+                    data["extension"] = text.ext_from_url(url)
+            else:
+                data = text.nameext_from_url(url, data)
+            data["file_url"] = url
+
+            yield Message.Directory, data
+            yield Message.Url, url, data
+
+    def posts(self):
+        """Return all relevant post objects"""
+
+    def _pagination(self, base_url):
+        headers = {"Referer": self.root}
+        page = 1
+        posts_found = True
+
+        while posts_found:
+            url = base_url+str(page)
+            url = text.ensure_http_scheme(url)
+            gallery_page_html = self.request(url, headers=headers).text
+            posts_found = False
+            for post_id in text.extract_iter(gallery_page_html, 'class="link-block" href="/posts/', '"'):
+                posts_found = True
+                for url, data in self._get_post_data_and_urls(post_id):
+                    yield url, data
+
+            page += 1
+
+    def _get_post_data_and_urls(self, post_id):
+        """Fetch and process post data"""
+        headers = {"Referer": self.root}
+        url = self.root+"/api/v1/posts/"+post_id
+        resp = self.request(url, headers=headers).json()["post"]
+        post = {
+            "post_id": resp["id"],
+            "post_url": self.root + "/posts/" + str(resp["id"]),
+            "post_title": resp["title"],
+            "comment": resp["comment"],
+            "rating": resp["rating"],
+            "posted_at": resp["posted_at"],
+            "fanclub_id": resp["fanclub"]["id"],
+            "fanclub_user_id": resp["fanclub"]["user"]["id"],
+            "fanclub_user_name": resp["fanclub"]["user"]["name"],
+            "fanclub_name": resp["fanclub"]["name"],
+            "fanclub_url": self.root + "/fanclubs/" + str(resp["fanclub"]["id"]),
+            "tags": resp["tags"]
+        }
+
+        if "thumb" in resp and resp["thumb"] and "original" in resp["thumb"]:
+            post["content_filename"] = ""
+            post["content_category"] = "thumb"
+            post["file_id"] = "thumb"
+            yield resp["thumb"]["original"], post
+
+        for content in resp["post_contents"]:
+            post["content_category"] = content["category"]
+            post["content_title"] = content["title"]
+            post["content_filename"] = content.get("filename", "")
+            post["content_id"] = content["id"]
+            if "post_content_photos" in content:
+                for photo in content["post_content_photos"]:
+                    post["file_id"] = photo["id"]
+                    yield photo["url"]["original"], post
+            if "download_uri" in content:
+                post["file_id"] = content["id"]
+                yield self.root+"/"+content["download_uri"], post
+
+class FantiaCreatorExtractor(FantiaExtractor):
+    """Extractor for a creator's works"""
+    subcategory = "creator"
+    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/fanclubs/([^/?#]+)"
+    test = (
+        ("https://fantia.jp/fanclubs/6939", {
+            "range": "1-25",
+            "count": ">= 25",
+            "keyword": {
+                "fanclub_user_id" : 52152,
+                "tags"            : list,
+                "title"           : str,
+            },
+        }),
+    )
+
+    def __init__(self, match):
+        FantiaExtractor.__init__(self, match)
+        self.creator_id = match.group(1)
+
+    def posts(self):
+        base_url = self.root+"/fanclubs/"+self.creator_id+"/posts?page="
+
+        return self._pagination(base_url)
+
+class FantiaPostExtractor(FantiaExtractor):
+    """Extractor for media from a single post"""
+    subcategory = "post"
+    pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/posts/([^/?#]+)"
+    test = (
+        ("https://fantia.jp/posts/508363", {
+            "count": 6,
+            "keyword": {
+                "post_title": "zunda逆バニーでおしりｺｯｼｮﾘ",
+                "tags": list,
+                "rating": "adult",
+                "post_id": 508363
+            },
+        }),
+    )
+
+    def __init__(self, match):
+        FantiaExtractor.__init__(self, match)
+        self.post_id = match.group(1)
+
+    def posts(self):
+        return self._get_post_data_and_urls(self.post_id)

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -11,7 +11,7 @@ from .. import text
 
 
 class FantiaExtractor(Extractor):
-    """Base class for fantia extractors"""
+    """Base class for Fantia extractors"""
     category = "fantia"
     root = "https://fantia.jp"
     directory_fmt = ("{category}", "{fanclub_id}")

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -143,4 +143,4 @@ class FantiaPostExtractor(FantiaExtractor):
         self.post_id = match.group(1)
 
     def posts(self):
-        yield self._get_post_data(self.post_id)
+        return (self.post_id,)

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -30,7 +30,8 @@ class FantiaExtractor(Extractor):
         for full_response, post in self.posts():
             yield Message.Directory, post
             for url, url_data in self._get_urls_from_post(full_response, post):
-                text.nameext_from_url(url_data["content_filename"] or url, url_data)
+                fname = url_data["content_filename"] or url
+                text.nameext_from_url(fname, url_data)
                 url_data["file_url"] = url
                 yield Message.Url, url, url_data
 

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -99,7 +99,7 @@ class FantiaExtractor(Extractor):
 
 
 class FantiaCreatorExtractor(FantiaExtractor):
-    """Extractor for a fantia creator's works"""
+    """Extractor for a Fantia creator's works"""
     subcategory = "creator"
     pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/fanclubs/([^/?#]+)"
     test = (
@@ -125,7 +125,7 @@ class FantiaCreatorExtractor(FantiaExtractor):
 
 
 class FantiaPostExtractor(FantiaExtractor):
-    """Extractor for media from a single fantia post"""
+    """Extractor for media from a single Fantia post"""
     subcategory = "post"
     pattern = r"(?:https?://)?(?:www\.)?fantia\.jp/posts/([^/?#]+)"
     test = (

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -27,7 +27,8 @@ class FantiaExtractor(Extractor):
                 self.log.warning("no '_session_id' cookie set")
             FantiaExtractor._warning = False
 
-        for full_response, post in self.posts():
+        for post_id in self.posts():
+            full_response, post = self._get_post_data(post_id)
             yield Message.Directory, post
             for url, url_data in self._get_urls_from_post(full_response, post):
                 fname = url_data["content_filename"] or url
@@ -36,9 +37,9 @@ class FantiaExtractor(Extractor):
                 yield Message.Url, url, url_data
 
     def posts(self):
-        """Return all relevant post objects"""
+        """Return post IDs"""
 
-def _pagination(self, url):
+    def _pagination(self, url):
         params = {"page": 1}
         headers = {"Referer": self.root}
 

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -38,23 +38,21 @@ class FantiaExtractor(Extractor):
     def posts(self):
         """Return all relevant post objects"""
 
-    def _pagination(self, base_url):
+def _pagination(self, url):
+        params = {"page": 1}
         headers = {"Referer": self.root}
-        page = 1
-        posts_found = True
 
-        while posts_found:
-            url = base_url+str(page)
-            url = text.ensure_http_scheme(url)
-            gallery_page_html = self.request(url, headers=headers).text
-            posts_found = False
+        while True:
+            page = self.request(url, params=params, headers=headers).text
+
+            post_id = None
             for post_id in text.extract_iter(
-                gallery_page_html, 'class="link-block" href="/posts/', '"'
-            ):
-                posts_found = True
-                yield self._get_post_data(post_id)
+                    page, 'class="link-block" href="/posts/', '"'):
+                yield post_id
 
-            page += 1
+            if not post_id:
+                return
+            params["page"] += 1
 
     def _get_post_data(self, post_id):
         """Fetch and process post data"""

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -118,9 +118,8 @@ class FantiaCreatorExtractor(FantiaExtractor):
         self.creator_id = match.group(1)
 
     def posts(self):
-        base_url = self.root+"/fanclubs/"+self.creator_id+"/posts?page="
-
-        return self._pagination(base_url)
+        url = "{}/fanclubs/{}/posts".format(self.root, self.creator_id)
+        return self._pagination(url)
 
 
 class FantiaPostExtractor(FantiaExtractor):

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -204,6 +204,8 @@ AUTH_MAP = {
     "e621"           : "Supported",
     "e-hentai"       : "Supported",
     "exhentai"       : "Supported",
+    "fanbox"         : _COOKIES,
+    "fantia"         : _COOKIES,
     "flickr"         : _OAUTH,
     "furaffinity"    : _COOKIES,
     "idolcomplex"    : "Supported",


### PR DESCRIPTION
Implemented post and user extractors for Fantia and Fanbox. Both use cookies for auth.
Doing it in 1 PR because these are pretty similar.

I added tests for both, however I don't know how to pass cookies to test_results.py so I didn't manage to run the Fantia tests.
The tests use freely available content, but registration (and for Fantia, subscription to the free plan) is likely needed.

Note that the test urls contain NSFW content (it's hard to find freely available + sfw on these sites).

Closes #849.
Closes #1260. 
Closes #739.