### PR TITLE
[pixiv] also save untranslated tags when translated-tags is enabled

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -46,6 +46,10 @@ class PixivExtractor(Extractor):
             del work["image_urls"]
             del work["meta_pages"]
             work["num"] = 0
+            if self.translated_tags:
+                work["untranslated_tags"] = [
+                    tag["name"] for tag in work["tags"]
+                ]
             work["tags"] = [tag[tkey] or tag["name"] for tag in work["tags"]]
             work["date"] = text.parse_datetime(work["create_date"])
             work["rating"] = ratings.get(work["x_restrict"])


### PR DESCRIPTION
A simple one. I want to save both the translated and untranslated tag versions from pixiv, so this change adds the untranslated tags when translated-tags is enabled. Save it into a separate entry instead of having pairs in "tags" to preserve backwards compat.