### PR TITLE
implement max-rank for pixiv

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1398,14 +1398,14 @@ Description
 .. __: https://github.com/mikf/gallery-dl/blob/v1.12.3/docs/gallery-dl-example.conf#L9-L14
 
 
-extractor.pixiv.max-rank
-------------------------
+extractor.pixiv.max-posts
+-------------------------
 Type
     ``integer``
 Default
     ``0``
 Description
-    When downloading ranking pages, this sets the maximum number of posts to get.
+    When downloading galleries, this sets the maximum number of posts to get.
     A value of ``0`` means no limit.
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1398,6 +1398,17 @@ Description
 .. __: https://github.com/mikf/gallery-dl/blob/v1.12.3/docs/gallery-dl-example.conf#L9-L14
 
 
+extractor.pixiv.max-rank
+------------------------
+Type
+    ``integer``
+Default
+    ``0``
+Description
+    When downloading ranking pages, this sets the maximum number of posts to get.
+    A value of ``0`` means no limit.
+
+
 extractor.plurk.comments
 ------------------------
 Type

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -387,9 +387,14 @@ class PixivRankingExtractor(PixivExtractor):
         PixivExtractor.__init__(self, match)
         self.query = match.group(1)
         self.mode = self.date = None
+        self.max_rank = self.config("max-rank", 0)
 
     def works(self):
-        return self.api.illust_ranking(self.mode, self.date)
+        ranking_iter = self.api.illust_ranking(self.mode, self.date)
+        if self.max_rank:
+            return itertools.islice(ranking_iter, self.max_rank)
+        else:
+            return ranking_iter
 
     def metadata(self):
         query = text.parse_query(self.query)


### PR DESCRIPTION
I want to download the top N posts from a ranking page where N is configurable. I did not find a way to do this (image-range is not good since a pixiv post may have many images). This PR adds an option to achieve this.