### PR TITLE
recognize v2.mangapark URLs

### DIFF
--- a/gallery_dl/extractor/mangapark.py
+++ b/gallery_dl/extractor/mangapark.py
@@ -51,7 +51,7 @@ class MangaparkBase():
 
 class MangaparkChapterExtractor(MangaparkBase, ChapterExtractor):
     """Extractor for manga-chapters from mangapark.net"""
-    pattern = (r"(?:https?://)?(?:www\.)?mangapark\.(me|net|com)"
+    pattern = (r"(?:https?://)?(?:www\.|v2\.)?mangapark\.(me|net|com)"
                r"/manga/([^?#]+/i\d+)")
     test = (
         ("https://mangapark.net/manga/gosu/i811653/c055/1", {
@@ -117,7 +117,7 @@ class MangaparkChapterExtractor(MangaparkBase, ChapterExtractor):
 class MangaparkMangaExtractor(MangaparkBase, MangaExtractor):
     """Extractor for manga from mangapark.net"""
     chapterclass = MangaparkChapterExtractor
-    pattern = (r"(?:https?://)?(?:www\.)?mangapark\.(me|net|com)"
+    pattern = (r"(?:https?://)?(?:www\.|v2\.)?mangapark\.(me|net|com)"
                r"(/manga/[^/?#]+)/?$")
     test = (
         ("https://mangapark.net/manga/aria", {

--- a/gallery_dl/extractor/mangapark.py
+++ b/gallery_dl/extractor/mangapark.py
@@ -17,7 +17,7 @@ import re
 class MangaparkBase():
     """Base class for mangapark extractors"""
     category = "mangapark"
-    root_fmt = "https://mangapark.{}"
+    root_fmt = "https://v2.mangapark.{}"
     browser = "firefox"
 
     @staticmethod


### PR DESCRIPTION
URLs like https://www.mangapark.net/manga/aria are redirected now to the v2 subdomain: https://v2.mangapark.net/manga/aria
This patch makes gallery-dl recognize these v2.mangapark URLs.

Looks like there is a "v3 beta" version of the site now, which has become the default. I don't really use the site so I did not investigate further compatibility with v3 beyond seeing that the URL formats are different. For now, the extractor seems to work fine with the v2 version.