### PR TITLE
Fix URL extraction for imagevenue.com

### DIFF
--- a/gallery_dl/extractor/imagehosts.py
+++ b/gallery_dl/extractor/imagehosts.py
@@ -143,8 +143,8 @@ class ImagevenueImageExtractor(ImagehostImageExtractor):
     https = False
 
     def get_info(self, page):
-        url = text.extract(page, "SRC='", "'")[0]
-        return text.urljoin(self.page_url, url), url
+        url = 'https://cdno-data' + text.extract(page, 'cdno-data', '"')[0]
+        return url, url
 
 
 class ImagetwistImageExtractor(ImagehostImageExtractor):


### PR DESCRIPTION
The URL extraction for imagevenue didn't work anymore, so I fixed it.

But: imagevenue seem to use a new URL pattern for their hosted images. I uploaded a new test image here: https://www.imagevenue.com/ME13LF6G and the URL is vastly different from the old version that can be found in the test case.

My knowledge on regular expressions is not wide enough to provide a regex that matches the new and the old URL pattern at the same time, so I would appreciate some help here.