### PR TITLE
fix(hitomi): fix images func

### DIFF
--- a/gallery_dl/extractor/hitomi.py
+++ b/gallery_dl/extractor/hitomi.py
@@ -140,11 +140,11 @@ class HitomiGalleryExtractor(GalleryExtractor):
 
             # see https://ltn.hitomi.la/common.js
             inum = int(ihash[-3:-1], 16)
-            frontends = 2 if inum < 0x70 else 3
-            inum = 1 if inum < 0x49 else inum
+            o = 1 if inum < 0x80 else 0
+            o = 2 if inum < 0x40 else 0
 
             url = "https://{}b.hitomi.la/images/{}/{}/{}.{}".format(
-                chr(97 + (inum % frontends)),
+                chr(97 + o),
                 ihash[-1], ihash[-3:-1], ihash,
                 idata["extension"],
             )


### PR DESCRIPTION
https://ltn.hitomi.la/common.js was changed

It seems that the ``number_of_frontends`` variable and ``subdomain_from_galleryid`` function are no longer used.

And the ``rewrite_tn_paths`` function was added. (but not include in this PR)

Changed according to the existing code style




