### PR TITLE
[kemonoparty] Duplicate file fix

### DIFF
--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -60,7 +60,6 @@ class KemonopartyExtractor(Extractor):
                 append(file)
             for attachment in post["attachments"]:
                 attachment["type"] = "attachment"
-                got_attachment = True
                 append(attachment)
             for path in find_inline(post["content"] or ""):
                 append({"path": path, "name": path, "type": "inline"})

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -51,9 +51,11 @@ class KemonopartyExtractor(Extractor):
             files = []
             append = files.append
             file = post["file"]
-            got_attachment = False
+            
+            # issue 1667 - patreon posts duplicate their main image in the attachments (sometimes)
+            should_skip_main_file = post["service"] == "patreon" and not post["attachments"]
 
-            if file:
+            if file and not should_skip_main_file:
                 file["type"] = "file"
                 append(file)
             for attachment in post["attachments"]:
@@ -62,9 +64,6 @@ class KemonopartyExtractor(Extractor):
                 append(attachment)
             for path in find_inline(post["content"] or ""):
                 append({"path": path, "name": path, "type": "inline"})
-                
-            if post["service"] == "patreon" and got_attachment:
-                files = files[1:] # ignore the first file if there are attachments
 
             post["date"] = text.parse_datetime(
                 post["published"], "%a, %d %b %Y %H:%M:%S %Z")

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -54,8 +54,9 @@ class KemonopartyExtractor(Extractor):
 
             # issue 1667 - patreon posts duplicate their main image
             # in the attachments (sometimes)
+            # solution: skip the main file if there are attachments
             should_skip_main_file = post["service"] == "patreon" \
-            and not post["attachments"]
+                and post["attachments"]
 
             if file and not should_skip_main_file:
                 file["type"] = "file"

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -63,7 +63,7 @@ class KemonopartyExtractor(Extractor):
             for path in find_inline(post["content"] or ""):
                 append({"path": path, "name": path, "type": "inline"})
                 
-            if got_attachment:
+            if post["service"] == "patreon" and got_attachment:
                 files = files[1:] # ignore the first file if there are attachments
 
             post["date"] = text.parse_datetime(

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -51,9 +51,11 @@ class KemonopartyExtractor(Extractor):
             files = []
             append = files.append
             file = post["file"]
-            
-            # issue 1667 - patreon posts duplicate their main image in the attachments (sometimes)
-            should_skip_main_file = post["service"] == "patreon" and not post["attachments"]
+
+            # issue 1667 - patreon posts duplicate their main image
+            # in the attachments (sometimes)
+            should_skip_main_file = post["service"] == "patreon" \
+            and not post["attachments"]
 
             if file and not should_skip_main_file:
                 file["type"] = "file"

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -51,15 +51,20 @@ class KemonopartyExtractor(Extractor):
             files = []
             append = files.append
             file = post["file"]
+            got_attachment = False
 
             if file:
                 file["type"] = "file"
                 append(file)
             for attachment in post["attachments"]:
                 attachment["type"] = "attachment"
+                got_attachment = True
                 append(attachment)
             for path in find_inline(post["content"] or ""):
                 append({"path": path, "name": path, "type": "inline"})
+                
+            if got_attachment:
+                files = files[1:] # ignore the first file if there are attachments
 
             post["date"] = text.parse_datetime(
                 post["published"], "%a, %d %b %Y %H:%M:%S %Z")


### PR DESCRIPTION
Fixes #1667 

Judging by the discussion in that thread, the first file is always duplicated in the attachments list, except for some posts which only have the image and no attachments.

This change makes it so if attachments are present it only downloads those.

It might require testing from various posts though. It worked in the one I tried for what it's worth, but I'm not too familiar with the service.