### PR TITLE
[bbc] - Add Support for Gallery Pages

### DIFF
--- a/gallery_dl/extractor/bbc.py
+++ b/gallery_dl/extractor/bbc.py
@@ -63,9 +63,9 @@ class BbcProgrammeExtractor(Extractor):
     pattern = BASE_PATTERN + r"[^/?#]+/galleries?[^/#]+)"
     test = (
         ("https://www.bbc.co.uk/programmes/b006q2x0/galleries", {
-        "pattern": BbcGalleryExtractor.pattern,
-        "count": ">= 24",
-        }),
+            "pattern": BbcGalleryExtractor.pattern,
+            "count": ">= 24",
+            }),
         ("https://www.bbc.co.uk/programmes/b006q2x0/galleries?page=5"),
     )
 

--- a/gallery_dl/extractor/bbc.py
+++ b/gallery_dl/extractor/bbc.py
@@ -65,7 +65,7 @@ class BbcProgrammeExtractor(Extractor):
         ("https://www.bbc.co.uk/programmes/b006q2x0/galleries", {
             "pattern": BbcGalleryExtractor.pattern,
             "count": ">= 24",
-            }),
+        }),
         ("https://www.bbc.co.uk/programmes/b006q2x0/galleries?page=5"),
     )
 

--- a/gallery_dl/extractor/bbc.py
+++ b/gallery_dl/extractor/bbc.py
@@ -60,11 +60,14 @@ class BbcProgrammeExtractor(Extractor):
     category = "bbc"
     subcategory = "programme"
     root = "https://www.bbc.co.uk"
-    pattern = BASE_PATTERN + r"[^/?#]+/galleries)"
-    test = ("https://www.bbc.co.uk/programmes/b006q2x0/galleries", {
+    pattern = BASE_PATTERN + r"[^/?#]+/galleries?[^/#]+)"
+    test = (
+        ("https://www.bbc.co.uk/programmes/b006q2x0/galleries", {
         "pattern": BbcGalleryExtractor.pattern,
         "count": ">= 24",
-    })
+        }),
+        ("https://www.bbc.co.uk/programmes/b006q2x0/galleries?page=5"),
+    )
 
     def __init__(self, match):
         Extractor.__init__(self, match)


### PR DESCRIPTION
Expand RegEx Pattern for `BbcProgrammeExtractor` to support gallery pages, e.g. `https://www.bbc.co.uk/programmes/b006q2x0/galleries?page=5`

This is my first PR here, so hopefully all is ok. I am not 100% certain on the tests, so any issues, please do let me know.

Tested the code locally and the pages downloaded as expected.