### PR TITLE
[Deviantart] [#1776] Remove the "you need session cookies to download mature scraps" warning

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -890,12 +890,9 @@ class DeviantartScrapsExtractor(DeviantartExtractor):
     )
     cookiedomain = ".deviantart.com"
     cookienames = ("auth", "auth_secure", "userinfo")
-    _warning = True
 
     def deviations(self):
         eclipse_api = DeviantartEclipseAPI(self)
-        if self._warning:
-            DeviantartScrapsExtractor._warning = False
 
         for obj in eclipse_api.gallery_scraps(self.user, self.offset):
             deviation = obj["deviation"]

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -896,9 +896,6 @@ class DeviantartScrapsExtractor(DeviantartExtractor):
         eclipse_api = DeviantartEclipseAPI(self)
         if self._warning:
             DeviantartScrapsExtractor._warning = False
-            if not self._check_cookies(self.cookienames):
-                self.log.warning(
-                    "No session cookies set: Unable to fetch mature scraps.")
 
         for obj in eclipse_api.gallery_scraps(self.user, self.offset):
             deviation = obj["deviation"]


### PR DESCRIPTION
To my knowledge, gallery-dl can download mature scraps from deviantart without cookies depsite the warning (see #1776 for details)

I haven't tested all the possible edge-cases yet (hence the PR being a draft). I'm putting this here mostly just to get used to pull requests