### PR TITLE
[Twitter] [#1532] Add account URL to --write-metadata and expand t.co links in user descriptions

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -217,6 +217,7 @@ class TwitterExtractor(Extractor):
                 "name"            : user["screen_name"],
                 "nick"            : user["name"],
                 "description"     : user["description"],
+                "url"             : "",
                 "location"        : user["location"],
                 "date"            : text.parse_datetime(
                     user["created_at"], "%a %b %d %H:%M:%S %z %Y"),
@@ -231,6 +232,11 @@ class TwitterExtractor(Extractor):
                 "media_count"     : user["media_count"],
                 "statuses_count"  : user["statuses_count"],
             }
+            if "urls" in user["entities"]["description"]:
+                for tco in user["entities"]["description"]["urls"]:
+                    cache[uid]["description"]=cache[uid]["description"].replace(tco["url"], tco["expanded_url"])
+            if "url" in user["entities"]:
+                cache[uid]["url"]=user["entities"]["url"]["urls"][0]["expanded_url"]
         return cache[uid]
 
     def _users_result(self, users):


### PR DESCRIPTION
It wouldn't make much sense to put these in separate pull requests so I just joined them

It's messy code and still needs to be tested but basically it

1. Fixes t.co links in a user's bio when doing `--write-metadata` in the same way https://github.com/mikf/gallery-dl/commit/41457dbb1b693664d52145e047953a3fa0c9dee0 was done
2. Adds the "here is my site" field to the written metadata since it was absent for some reason

Side note: The JSON for the t.co replacement stuff is really weird. If there's no t.co links in the bio `user["entities"]["description"]` is empty but for the "my site" link `user["entities"]["url"]` is just gone. You'd think it'd be a bit more consistent than that