### PR TITLE
[kemonoparty] Fix file download URLs

### DIFF
--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -69,9 +69,8 @@ class KemonopartyExtractor(Extractor):
 
             for post["num"], file in enumerate(files, 1):
                 post["type"] = file["type"]
-                url = file["path"]
                 if url[0] == "/":
-                    url = self.root + url
+                    url = self.root + '/data' + url.replace(self.root, '')
 
                 text.nameext_from_url(file["name"], post)
                 yield Message.Url, url, post


### PR DESCRIPTION
File paths now need to be prepended with `/data`. Sorry for the sudden breaking change.

