### PR TITLE
[webtoons] Use swebtoon-phinf.pstatic.net instead of webtoon-phinf.pstatic.net

### DIFF
--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -48,7 +48,7 @@ class WebtoonsEpisodeExtractor(WebtoonsBase, GalleryExtractor):
     test = (
         (("https://www.webtoons.com/en/comedy/safely-endangered"
           "/ep-572-earth/viewer?title_no=352&episode_no=572"), {
-            "url": "11041d71a3f92728305c11a228e77cf0f7aa02ef",
+            "url": "55bec5d7c42aba19e3d0d56db25fdf0b0b13be38",
             "content": ("1748c7e82b6db910fa179f6dc7c4281b0f680fa7",
                         "42055e44659f6ffc410b3fb6557346dfbb993df3",
                         "49e1f2def04c6f7a6a3dacf245a1cd9abe77a6a9"),
@@ -87,12 +87,7 @@ class WebtoonsEpisodeExtractor(WebtoonsBase, GalleryExtractor):
     @staticmethod
     def images(page):
         return [
-            (
-                url.replace(
-                    "webtoon-phinf.pstatic.net", "swebtoon-phinf.pstatic.net"
-                ),
-                None
-            )
+            (url.replace("://webtoon-phinf.", "://swebtoon-phinf."), None)
             for url in text.extract_iter(
                 page, 'class="_images" data-url="', '"')
         ]

--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -62,7 +62,6 @@ class WebtoonsEpisodeExtractor(WebtoonsBase, GalleryExtractor):
         url = "{}/{}/viewer?{}".format(self.root, self.path, query)
         GalleryExtractor.__init__(self, match, url)
         self.setup_agegate_cookies()
-        self.session.headers["Referer"] = url
 
         query = text.parse_query(query)
         self.title_no = query.get("title_no")
@@ -88,7 +87,12 @@ class WebtoonsEpisodeExtractor(WebtoonsBase, GalleryExtractor):
     @staticmethod
     def images(page):
         return [
-            (url, None)
+            (
+                url.replace(
+                    "webtoon-phinf.pstatic.net", "swebtoon-phinf.pstatic.net"
+                ),
+                None
+            )
             for url in text.extract_iter(
                 page, 'class="_images" data-url="', '"')
         ]


### PR DESCRIPTION
We'll be using this chapter as an example:
https://www.webtoons.com/en/thriller/school-bus-graveyard/episode-18/viewer?title_no=2705&episode_no=18

This neat trick actually comes from Webtoon's RSS feeds, where a
Referer header is unrealistic. Here's the RSS feed:
https://www.webtoons.com/en/thriller/school-bus-graveyard/rss?title_no=2705
They use URLs like this:

https://swebtoon-phinf.pstatic.net/20210929_12/1632867976494qzHhY_JPEG/16328679717202705189.jpg

The image links Webtoon's online client use URLs like this:

https://webtoon-phinf.pstatic.net/20210929_12/1632867976494qzHhY_JPEG/16328679717202705189.jpg?type=q90

Look familiar?

Yes, you only need to change the domain of your URL from
webtoon-phinf.pstatic.net to swebtoon-phinf.pstatic.net, a difference
of one character, to be able to embed Webtoon images anywhere. This
isn't limited to just the two images an RSS feed item has. Here's
another image from the same chapter much further down the page:

https://webtoon-phinf.pstatic.net/20210929_153/1632867980912DmcGK_JPEG/16328679808882705182.jpg?type=q90

https://swebtoon-phinf.pstatic.net/20210929_153/1632867980912DmcGK_JPEG/16328679808882705182.jpg?type=q90

With this, the doors have been blown open.

If this ever changes, previous behavior can be easily restored using `git revert` due to this patch's small size.