### PR TITLE
[instagram] Download avatars for user profiles

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1328,6 +1328,16 @@ Description
     Download video files.
 
 
+extractor.instagram.avatar
+--------------------------
+Type
+    ``bool``
+Default
+    ``false``
+Description
+    Download user avatars.
+
+
 extractor.kemonoparty.comments
 -----------------------------
 Type

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -427,7 +427,8 @@ class InstagramUserExtractor(InstagramExtractor):
             # this shouldn't be an issue because if the avatar is changed,
             # the new avatar will have a profile_pic_id
             data = {
-                "media_id"   : info.get("profile_pic_id", "avatar_" + user["id"]),
+                "media_id"   : info.get("profile_pic_id",
+                                        "avatar_" + user["id"]),
                 "owner_id"   : user["id"],
                 "display_url": avatar["url"],
                 "height"     : avatar["height"],

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -423,7 +423,7 @@ class InstagramUserExtractor(InstagramExtractor):
             avatar = info["hd_profile_pic_url_info"]
 
             # users that haven't had their avatar changed in long time
-            # don't have a profile_pic_id, so we need to fall back to the user id,
+            # don't have a profile_pic_id, so we use the user id instead,
             # this shouldn't be an issue because if the avatar is changed,
             # the new avatar will have a profile_pic_id
             data = {

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -422,8 +422,12 @@ class InstagramUserExtractor(InstagramExtractor):
 
             avatar = info["hd_profile_pic_url_info"]
 
+            # users that haven't had their avatar changed in long time
+            # don't have a profile_pic_id, so we need to fall back to the user id,
+            # this shouldn't be an issue because if the avatar is changed,
+            # the new avatar will have a profile_pic_id
             data = {
-                "media_id"   : info["profile_pic_id"],
+                "media_id"   : info.get("profile_pic_id", "avatar_" + user["id"]),
                 "owner_id"   : user["id"],
                 "display_url": avatar["url"],
                 "height"     : avatar["height"],


### PR DESCRIPTION
This pull request adds a configuration option to download the profile picture/avatar when downloading an Instagram user profile.

In my testing this will download a profile picture with a maximum resolution of 1080x1080 pixels, lower if the user doesn't have a profile picture that large.

Closes #1097 