### PR TITLE
[Webtoons] Upgrade requests & certifi to upgrade certificate bundle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests>=2.11.0
+requests>=2.21.0
+certifi>=2021.10.8


### PR DESCRIPTION
*Please note that this is my first time working with python, so please give me any pointers if I need to change anything.*

As noted in #2090, the certificate bundle used by the version of requests is out of date. Causing SSL errors when trying to connect. I have fixed this by upgrading requests to the latest version stat still supports python 3.5. And separately upgrading the certificate bundle that requests uses to the latest available version.

This fixed the webtoons download for me (``gallery-dl.exe 'https://www.webtoons.com/en/challenge/goblins-of-razard/list?title_no=389342&page=1'``)