### PR TITLE
[instagram] fix highlights extraction

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -748,23 +748,19 @@ class InstagramHighlightsExtractor(InstagramExtractor):
 
         endpoint = "/v1/highlights/{}/highlights_tray/".format(user["id"])
         tray = self._request_api(endpoint)["tray"]
-
         reel_ids = [highlight["id"] for highlight in tray]
 
         # Anything above 30 responds with statuscode 400.
         # 30 can work, however, sometimes the API will respond with 560 or 500.
-        chunk_size = 15
-        chunked_reel_ids = [reel_ids[offset:offset + chunk_size]
-                            for offset in range(0, len(reel_ids), chunk_size)]
-
-        reels = []
+        chunk_size = 5
         endpoint = "/v1/feed/reels_media/"
-        for chunk_ids in chunked_reel_ids:
-            params = {"reel_ids": chunk_ids}
-            chunk_reels = self._request_api(endpoint, params=params)["reels"]
-            reels += [chunk_reels[rid] for rid in chunk_ids]
 
-        return reels
+        for offset in range(0, len(reel_ids), chunk_size):
+            chunk_ids = reel_ids[offset : offset+chunk_size]
+            params = {"reel_ids": chunk_ids}
+            reels = self._request_api(endpoint, params=params)["reels"]
+            for reel_id in chunk_ids:
+                yield reels[reel_id]
 
 
 class InstagramReelsExtractor(InstagramExtractor):


### PR DESCRIPTION
Currently the highlight extractor fails when there are more than 30 reel_ids supplied to the "/v1/feed/reels_media/" endpoint. 

For example, fetching highlights from "https://www.instagram.com/f1/" (87 highlights at the time I'm writing this)

```sh
gallery-dl -v --no-download -o include="highlights" "https://www.instagram.com/f1/"
```

will respond with status code 400.

Initially I tried splitting reel_ids into chunks of length 30, however, I quickly found that I consistently get 5xx responses when the total number of reel_ids is above 30 (I waited an entire week just to make sure that I wasn't being rate limited). When the total number of reel_ids is <= 30 (example account "https://www.instagram.com/bemytravelmuse/", 27 highlights at the time I'm writing this), you *can* fetch everything with a single request, *however*, in my case 5xx responses can still be frequently observed. 

I haven't tested everything thoroughly, but it looks like chunks of 15 seem to work most of the time. That being said, it might be a good idea to start at 30 and just reduce the chunk size (e.g. halve it) until you stop getting 5xx responses.
