### PR TITLE
[patreon] Disable TLS 1.2 by default

### DIFF
--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -64,7 +64,7 @@ class Extractor():
             self._retries = float("inf")
 
         self._additional_adapter_options = 0
-        if self.config("disabletls12"):
+        if self.config("disabletls12") or self.disabletls12:
             self._additional_adapter_options |= ssl.OP_NO_TLSv1_2
             self.log.info("TLS 1.2 disabled.")
 

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -26,6 +26,7 @@ class PatreonExtractor(Extractor):
     archive_fmt = "{id}_{num}"
     browser = "firefox"
     _warning = True
+    disabletls12 = True
 
     def items(self):
 


### PR DESCRIPTION
At the insistence of others, I updated the code a bit to disable TLS 1.2 by default on Patreon.  It is still a configurable option.

Should have really done this on the last PR but didn't think about it at the time.  Based on testing this should be good to go for Patreon.  Now people don't have to disable it manually in the config for Patreon.

Sorry to mikf since I know my last PR just got accepted recently.