### PR TITLE
Add two examples for custom instances of gelbooru

### DIFF
--- a/docs/gallery-dl-example.conf
+++ b/docs/gallery-dl-example.conf
@@ -6,6 +6,12 @@
         "#": "set global archive file for all extractors",
         "archive": "~/gallery-dl/archive.sqlite3",
 
+        "#": "add two custom keywords into the metadata dictionary",
+        "#": "these can be used to further refine your output directories or filenames",
+        "keywords": {"bkey": "", "ckey": ""},
+        "#": "make sure that custom keywords are empty, i.e. they don't appear unless specified by the user",
+        "keywords-default": "",
+
         "#": "replace invalid path characters with unicode alternatives",
         "path-restrict": {
             "\\": "⧹",
@@ -212,6 +218,74 @@
             "#": "add two other foolfuuka 4chan archives",
             "fireden-onion": {"root": "http://ydt6jy2ng3s3xg2e.onion"},
             "scalearchive" : {"root": "https://archive.scaled.team"  }
+        },
+
+        "gelbooru_v01":
+        {
+            "#": "add a custom gelbooru_v01 instance",
+            "#": "this is just an example, this specific instance is already included!",
+            "allgirlbooru": {"root": "https://allgirl.booru.org"},
+
+            "#": "the following options are used for all gelbooru_v01 instances",
+            "tag":
+            {
+                "directory": {
+                    "locals().get('bkey')": ["Booru", "AllGirlBooru", "Tags", "{bkey}", "{ckey}", "{search_tags}"],
+                    ""                    : ["Booru", "AllGirlBooru", "Tags", "_Unsorted", "{search_tags}"]
+                }
+            },
+            "post":
+            {
+                "directory": ["Booru", "AllGirlBooru", "Posts"]
+            },
+            "archive": "~/gallery-dl/custom-archive-file-for-gelbooru_v01_instances.db",
+            "filename": "{tags}_{id}_{md5}.{extension}",
+            "sleep-request": [0, 1.2]
+        },
+
+        "gelbooru_v02":
+        {
+            "#": "add a custom gelbooru_v02 instance",
+            "#": "this is just an example, this specific instance is already included!",
+            "tbib":
+            {
+                "root": "https://tbib.org",
+                "#": "some sites have different domains for API access",
+                "#": "use the 'api_root' option in addition to the 'root' setting here",
+
+                "#": "the following options are only used for TBIB",
+                "#": "gelbooru_v02 has four subcategories at the moment, use custom directory settings for all of these",
+                "tag":
+                {
+                    "directory": {
+                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Tags", "{bkey}", "{ckey}", "{search_tags}"],
+                        ""                    : ["Other Boorus", "TBIB", "Tags", "_Unsorted", "{search_tags}"]
+                    }
+                },
+                "pool":
+                {
+                    "directory": {
+                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Pools", "{bkey}", "{ckey}", "{pool}"],
+                        ""                    : ["Other Boorus", "TBIB", "Pools", "_Unsorted", "{pool}"]
+                    }
+                },
+                "favorite":
+                {
+                    "directory": {
+                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Favorites", "{bkey}", "{ckey}", "{favorite_id}"],
+                        ""                    : ["Other Boorus", "TBIB", "Favorites", "_Unsorted", "{favorite_id}"]
+                    }
+                },
+                "post":
+                {
+                    "directory": ["Other Boorus", "TBIB", "Posts"]
+                },
+                "archive": "~/gallery-dl/custom-archive-file-for-TBIB.db",
+                "filename": "{id}_{md5}.{extension}",
+                "sleep-request": [0, 1.2],
+                "username": "YourUsernameHere",
+                "password": "YourPasswordHere"
+            }
         }
     },
 

--- a/docs/gallery-dl-example.conf
+++ b/docs/gallery-dl-example.conf
@@ -251,41 +251,41 @@
             {
                 "root": "https://tbib.org",
                 "#": "some sites have different domains for API access",
-                "#": "use the 'api_root' option in addition to the 'root' setting here",
-
-                "#": "the following options are only used for TBIB",
-                "#": "gelbooru_v02 has four subcategories at the moment, use custom directory settings for all of these",
-                "tag":
-                {
-                    "directory": {
-                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Tags", "{bkey}", "{ckey}", "{search_tags}"],
-                        ""                    : ["Other Boorus", "TBIB", "Tags", "_Unsorted", "{search_tags}"]
-                    }
-                },
-                "pool":
-                {
-                    "directory": {
-                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Pools", "{bkey}", "{ckey}", "{pool}"],
-                        ""                    : ["Other Boorus", "TBIB", "Pools", "_Unsorted", "{pool}"]
-                    }
-                },
-                "favorite":
-                {
-                    "directory": {
-                        "locals().get('bkey')": ["Other Boorus", "TBIB", "Favorites", "{bkey}", "{ckey}", "{favorite_id}"],
-                        ""                    : ["Other Boorus", "TBIB", "Favorites", "_Unsorted", "{favorite_id}"]
-                    }
-                },
-                "post":
-                {
-                    "directory": ["Other Boorus", "TBIB", "Posts"]
-                },
-                "archive": "~/gallery-dl/custom-archive-file-for-TBIB.db",
-                "filename": "{id}_{md5}.{extension}",
-                "sleep-request": [0, 1.2],
-                "username": "YourUsernameHere",
-                "password": "YourPasswordHere"
+                "#": "use the 'api_root' option in addition to the 'root' setting here"
             }
+        },
+
+        "tbib": {
+            "#": "the following options are only used for TBIB",
+            "#": "gelbooru_v02 has four subcategories at the moment, use custom directory settings for all of these",
+            "tag":
+            {
+                "directory": {
+                    "locals().get('bkey')": ["Other Boorus", "TBIB", "Tags", "{bkey}", "{ckey}", "{search_tags}"],
+                    ""                    : ["Other Boorus", "TBIB", "Tags", "_Unsorted", "{search_tags}"]
+                }
+            },
+            "pool":
+            {
+                "directory": {
+                    "locals().get('bkey')": ["Other Boorus", "TBIB", "Pools", "{bkey}", "{ckey}", "{pool}"],
+                    ""                    : ["Other Boorus", "TBIB", "Pools", "_Unsorted", "{pool}"]
+                }
+            },
+            "favorite":
+            {
+                "directory": {
+                    "locals().get('bkey')": ["Other Boorus", "TBIB", "Favorites", "{bkey}", "{ckey}", "{favorite_id}"],
+                    ""                    : ["Other Boorus", "TBIB", "Favorites", "_Unsorted", "{favorite_id}"]
+                }
+            },
+            "post":
+            {
+                "directory": ["Other Boorus", "TBIB", "Posts"]
+            },
+            "archive": "~/gallery-dl/custom-archive-file-for-TBIB.db",
+            "filename": "{id}_{md5}.{extension}",
+            "sleep-request": [0, 1.2]
         }
     },
 


### PR DESCRIPTION
- First example uses some custom options at the "gelbooru_v01" basecategory
   These apply to all instances used herein
- Second example adds all options to the specific "gelbooru_v02" basecategory of TBIB
    These settings are only used by TBIB

If I'm reading that correctly, that is 🤣 

Tested this locally with my own config, seems to work though.