### PR TITLE
Adding numerical ordering to fantia

### DIFF
--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -29,8 +29,9 @@ class FantiaExtractor(Extractor):
         for post_id in self.posts():
             full_response, post = self._get_post_data(post_id)
             yield Message.Directory, post
-            for count, (url, url_data) in enumerate(self._get_urls_from_post(full_response, post), start=1):
-                post["num"] = count
+            post["num"] = 0
+            for url, url_data in self._get_urls_from_post(full_response, post):
+                post["num"] += 1
                 fname = url_data["content_filename"] or url
                 text.nameext_from_url(fname, url_data)
                 url_data["file_url"] = url

--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -29,7 +29,8 @@ class FantiaExtractor(Extractor):
         for post_id in self.posts():
             full_response, post = self._get_post_data(post_id)
             yield Message.Directory, post
-            for url, url_data in self._get_urls_from_post(full_response, post):
+            for count, (url, url_data) in enumerate(self._get_urls_from_post(full_response, post), start=1):
+                post["num"] = count
                 fname = url_data["content_filename"] or url
                 text.nameext_from_url(fname, url_data)
                 url_data["file_url"] = url


### PR DESCRIPTION
This PR request aims to bring numerical ordering for filenames for the posts downloaded from Fantia in case there is more than one file in a single post.

