### PR TITLE
Fix broken "special type formatter" \fT \fE \fM when running gallery-dl in Linux

### DIFF
--- a/gallery_dl/formatter.py
+++ b/gallery_dl/formatter.py
@@ -33,9 +33,11 @@ def parse(format_string, default=None):
         pass
 
     cls = StringFormatter
-    if format_string.startswith("\f"):
+
+    if format_string.startswith("\f") or format_string.startswith("\\f"):
         kind, _, format_string = format_string.partition(" ")
-        kind = kind[1:]
+
+        kind = kind[-1]
 
         if kind == "T":
             cls = TemplateFormatter


### PR DESCRIPTION
I want to use the "Special Type Format Strings" but gallery-dl completely ignores these formatters.

It seems that `\f` in the parameter --filename is converted to `\\f`.

By calling `gallery-dl -f "\fM test20220313:generate_text" https://some.web.site`, the argument `format_string` in `formatter.py:parse` is set to `\\fM test20220313:generate_text`. This breaks the detection and extraction of the special type formatters.

This pull request is a quick fix for this problem. Feel free to improve it.