### PR TITLE
[Unsplash] Fix UnsplashSearchExtractor by replacing dash with space

### DIFF
--- a/gallery_dl/extractor/unsplash.py
+++ b/gallery_dl/extractor/unsplash.py
@@ -193,7 +193,7 @@ class UnsplashSearchExtractor(UnsplashExtractor):
     """Extractor for unsplash search results"""
     subcategory = "search"
     pattern = BASE_PATTERN + r"/s/photos/([^/?#]+)(?:\?([^/?#]+))?"
-    test = ("https://unsplash.com/s/photos/nature", {
+    test = ("https://unsplash.com/s/photos/hair-style", {
         "pattern": r"https://images\.unsplash\.com/((flagged/)?photo-\d+-\w+"
                    r"|reserve/[^/?#]+)\?ixid=\w+&ixlib=rb-1\.2\.1$",
         "range": "1-30",
@@ -206,7 +206,7 @@ class UnsplashSearchExtractor(UnsplashExtractor):
 
     def photos(self):
         url = self.root + "/napi/search/photos"
-        params = {"query": text.unquote(self.item)}
+        params = {"query": text.unquote(self.item.replace('-', ' '))}
         if self.query:
             params.update(text.parse_query(self.query))
         return self._pagination(url, params, True)


### PR DESCRIPTION
When typing `hair style` in home page, the website will redirect you to https://unsplash.com/s/photos/hair-style. But when you roll down to get more images, it get data from https://unsplash.com/napi/search/photos?query=hair%20style where `-` is replaced with ` `.