### PR TITLE
[twitter] accept fxtwitter.com URLs

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -15,7 +15,7 @@ import json
 
 BASE_PATTERN = (
     r"(?:https?://)?(?:www\.|mobile\.)?"
-    r"(?:twitter\.com|nitter\.net)"
+    r"(?:(?:fx)?twitter\.com|nitter\.net)"
 )
 
 


### PR DESCRIPTION
fxtwitter.com is a service that somehow fixes twitter embeds on discord and other places. You simply replace twitter.com with fxtwitter.com when you post links in such services and you will get embeds. If you open the link, it will just redirect to twitter.com.
Recently I've seen a lot of people use this, so I think we should handle it here to avoid having to manually edit out the "fx" from URLs when passing to gallery-dl.