### PR TITLE
recognize vxtwitter URLs

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -403,6 +403,8 @@ class TwitterTimelineExtractor(TwitterExtractor):
         ("https://www.twitter.com/id:2976459548"),
         ("https://twitter.com/i/user/2976459548"),
         ("https://twitter.com/intent/user?user_id=2976459548"),
+        ("https://fxtwitter.com/supernaturepics"),
+        ("https://vxtwitter.com/supernaturepics"),
     )
 
     def __init__(self, match):

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -15,7 +15,7 @@ import json
 
 BASE_PATTERN = (
     r"(?:https?://)?(?:www\.|mobile\.)?"
-    r"(?:(?:fx)?twitter\.com|nitter\.net)"
+    r"(?:(?:fx|vx)?twitter\.com|nitter\.net)"
 )
 
 

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -15,7 +15,7 @@ import json
 
 BASE_PATTERN = (
     r"(?:https?://)?(?:www\.|mobile\.)?"
-    r"(?:(?:fx|vx)?twitter\.com|nitter\.net)"
+    r"(?:(?:[fv]x)?twitter\.com|nitter\.net)"
 )
 
 


### PR DESCRIPTION
Now that fxtwitter.com fell out of favor/shut down, people switched to posting vxtwitter.com links (works the same as fxtwitter did).
I realize this is not a very scalable solution, so if other such sites pop up we might need a better way than just having the regex match them all, but for now it's probably still good enough.