### PR TITLE
[snap] Fix missing libslang dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -104,6 +104,7 @@ parts:
     plugin: nil
     stage-packages:
     - ffmpeg
+    - libslang2
 
 apps:
   gallery-dl:


### PR DESCRIPTION
Fixes #1531.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>