### PR TITLE
[postprocessor:mtime] add 'value' option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3464,6 +3464,24 @@ Description
     This value must either be a UNIX timestamp or a
     |datetime|_ object.
 
+    Note: This option gets ignored if `mtime.value`_ is set.
+
+
+mtime.value
+-----------
+Type
+    ``string``
+Default
+    ``null``
+Example
+    * ``"{status[date]}"``
+    * ``"{content[0:6]:R22/2022/D%Y%m%d/}"``
+Description
+    A `format string`_ whose value should be used.
+
+    The resulting value must either be a UNIX timestamp or a
+    |datetime|_ object.
+
 
 ugoira.extension
 ----------------

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -350,10 +350,6 @@ class MetadataTest(BasePostprocessorTest):
 
 class MtimeTest(BasePostprocessorTest):
 
-    def test_mtime_default(self):
-        pp = self._create()
-        self.assertEqual(pp.key, "date")
-
     def test_mtime_datetime(self):
         self._create(None, {"date": datetime(1980, 1, 1)})
         self._trigger()
@@ -364,8 +360,13 @@ class MtimeTest(BasePostprocessorTest):
         self._trigger()
         self.assertEqual(self.pathfmt.kwdict["_mtime"], 315532800)
 
-    def test_mtime_custom(self):
+    def test_mtime_key(self):
         self._create({"key": "foo"}, {"foo": 315532800})
+        self._trigger()
+        self.assertEqual(self.pathfmt.kwdict["_mtime"], 315532800)
+
+    def test_mtime_value(self):
+        self._create({"value": "{foo}"}, {"foo": 315532800})
         self._trigger()
         self.assertEqual(self.pathfmt.kwdict["_mtime"], 315532800)
 


### PR DESCRIPTION
Closes #2721.

I'm not at all familiar with reStructuredText, so I based a lot of the doc changes on other options.

I'm also not sure if setting `self.value_fmt` and then setting `self._value_fmt` is necessary, again I saw another place where something similar was done so I went with it for now.

I was also considering wrapping the value of `mtime.key` in braces as the default format string for `mtime.value`, and using it as the only value for `mtime`. Currently it defaults to an empty string.

A review is welcome.