### PR TITLE
[oauth] add host config option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1783,6 +1783,16 @@ Description
     in `cache <cache.file_>`__.
 
 
+extractor.oauth.host
+--------------------
+Type
+    ``string``
+Default
+    ``"localhost"``
+Description
+    Host name / IP address to bind to during OAuth authorization.
+
+
 extractor.oauth.port
 --------------------
 Type

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -198,6 +198,7 @@
         {
             "browser": true,
             "cache": true,
+            "host": "localhost",
             "port": 6414
         },
         "paheal":

--- a/gallery_dl/extractor/oauth.py
+++ b/gallery_dl/extractor/oauth.py
@@ -42,7 +42,7 @@ class OAuthBase(Extractor):
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         server.bind((self.config("host", "localhost"),
-                    self.config("port", 6414)))
+                     self.config("port", 6414)))
         server.listen(1)
 
         # workaround for ctrl+c not working during server.accept on Windows

--- a/gallery_dl/extractor/oauth.py
+++ b/gallery_dl/extractor/oauth.py
@@ -41,7 +41,8 @@ class OAuthBase(Extractor):
         stdout_write("Waiting for response. (Cancel with Ctrl+c)\n")
         server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server.bind(("localhost", self.config("port", 6414)))
+        server.bind((self.config("host", "localhost"),
+                    self.config("port", 6414)))
         server.listen(1)
 
         # workaround for ctrl+c not working during server.accept on Windows


### PR DESCRIPTION
There might be situations where you want to bind your oauth web server to something other than `localhost`.

F.e. if you use `gallery-dl` in a docker environment and you want to expose the oauth port to its network, there is  currently no way as you need to bind the host to `0.0.0.0` to be able to forward ports.

