### PR TITLE
[gelbooru] regex for extractor not allowing alternate parameter order in url.

### DIFF
--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -127,8 +127,6 @@ class GelbooruPoolExtractor(GelbooruBase,
 class GelbooruPostExtractor(GelbooruBase,
                             gelbooru_v02.GelbooruV02PostExtractor):
     """Extractor for single images from gelbooru.com"""
-    #pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
-    #r"\?page=post&s=view&id=(?P<post>\d+)")
     pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
                r"\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*")
 

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -127,8 +127,10 @@ class GelbooruPoolExtractor(GelbooruBase,
 class GelbooruPostExtractor(GelbooruBase,
                             gelbooru_v02.GelbooruV02PostExtractor):
     """Extractor for single images from gelbooru.com"""
-    #pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)/match()/?\?page=post&s=view&id=(?P<post>\d+")
-    pattern = (r"(?:https?:\/\/)?(?:www\.)?gelbooru\.com\/(?:index\.php)?\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*")
+    #pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
+    #r"\?page=post&s=view&id=(?P<post>\d+)")
+    pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
+               r"\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*")
 
     test = (
         ("https://gelbooru.com/index.php?page=post&s=view&id=313638", {

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -136,6 +136,14 @@ class GelbooruPostExtractor(GelbooruBase,
             "content": "5e255713cbf0a8e0801dc423563c34d896bb9229",
             "count": 1,
         }),
+
+        ("https://gelbooru.com/index.php?page=post&s=view&id=313638"),
+        ("https://gelbooru.com/index.php?s=view&page=post&id=313638"),
+        ("https://gelbooru.com/index.php?page=post&id=313638&s=view"),
+        ("https://gelbooru.com/index.php?s=view&id=313638&page=post"),
+        ("https://gelbooru.com/index.php?id=313638&page=post&s=view"),
+        ("https://gelbooru.com/index.php?id=313638&s=view&page=post"),
+
         ("https://gelbooru.com/index.php?page=post&s=view&id=6018318", {
             "options": (("tags", True),),
             "content": "977caf22f27c72a5d07ea4d4d9719acdab810991",

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -127,8 +127,9 @@ class GelbooruPoolExtractor(GelbooruBase,
 class GelbooruPostExtractor(GelbooruBase,
                             gelbooru_v02.GelbooruV02PostExtractor):
     """Extractor for single images from gelbooru.com"""
-    pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
-               r"\?page=post&s=view&id=(?P<post>\d+)")
+    #pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)/match()/?\?page=post&s=view&id=(?P<post>\d+")
+    pattern = (r"(?:https?:\/\/)?(?:www\.)?gelbooru\.com\/(?:index\.php)?\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*")
+
     test = (
         ("https://gelbooru.com/index.php?page=post&s=view&id=313638", {
             "content": "5e255713cbf0a8e0801dc423563c34d896bb9229",

--- a/gallery_dl/extractor/gelbooru.py
+++ b/gallery_dl/extractor/gelbooru.py
@@ -127,9 +127,10 @@ class GelbooruPoolExtractor(GelbooruBase,
 class GelbooruPostExtractor(GelbooruBase,
                             gelbooru_v02.GelbooruV02PostExtractor):
     """Extractor for single images from gelbooru.com"""
-    pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?"
-               r"\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*")
-
+    pattern = (r"(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?\?"
+               r"(?=(?:[^#]+&)?page=post(?:&|#|$))"
+               r"(?=(?:[^#]+&)?s=view(?:&|#|$))"
+               r"(?:[^#]+&)?id=(\d+)")
     test = (
         ("https://gelbooru.com/index.php?page=post&s=view&id=313638", {
             "content": "5e255713cbf0a8e0801dc423563c34d896bb9229",


### PR DESCRIPTION
The regex currently implemented wouldn't support urls where the `s, page, and id` orders were different. 

placing `page=post` and `s=view` into look-aheads from the `?` forward allows for any order while also checking if present.

URLs tested
```
1: https://gelbooru.com/index.php?page=post&s=view&id=7583325
2: https://gelbooru.com/index.php?page=post&s=view&id=7583325&tags=cat
3: https://gelbooru.com/index.php?id=7583325&page=post&s=view
```
Match 2 was gotten by searching for 'cat' and then clicking on an image. Seems gelbooru embeds search parameters


Old regex
```
(?:https?://)?(?:www\.)?gelbooru\.com/(?:index\.php)?\?page=post&s=view&id=(?P<post>\d+)
```
Results:
1: Match: `https://gelbooru.com/index.php?page=post&s=view&id=7586232`, Group post: `7586232`
2: Match: `https://gelbooru.com/index.php?page=post&s=view&id=7586232`, Group post: `7586232`
3: No match

New regex
```
(?:https?:\/\/)?(?:www\.)?gelbooru\.com\/(?:index\.php)?\?(?=.*page=post)(?=.*s=view).*id=(?P<post>\d+).*
```

Results:
1: Match: `https://gelbooru.com/index.php?page=post&s=view&id=7586232`, Group post: `7586232`
2: Match: `https://gelbooru.com/index.php?page=post&s=view&id=7582526&tags=cat`, Group post `7586232`
3: Match: `https://gelbooru.com/index.php?id=7586232&page=post&s=view`, Group post: `7586232`

I was unable to determine if the old regex was made with the intention of sanitizing additional arguments ( such as removing `&tag=cat`) or if it was just a byproduct or a 'bonus' of the regex






