### PR TITLE
job.py: add epoch keyword with datetime obj storing time of extraction

### DIFF
--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -13,6 +13,7 @@ import errno
 import logging
 import functools
 import collections
+import datetime
 from . import extractor, downloader, postprocessor
 from . import config, text, util, path, formatter, output, exception
 from .extractor.message import Message
@@ -154,6 +155,7 @@ class Job():
         extr = self.extractor
         kwdict["category"] = extr.category
         kwdict["subcategory"] = extr.subcategory
+        kwdict["epoch"] = datetime.datetime.now()
         if self.kwdict:
             kwdict.update(self.kwdict)
 


### PR DESCRIPTION
This is equivalent to the yt-dlp/youtube-dl key of the same name, except that stores the Unix time of extraction as an integer.

There is a `_now` field in the string format for filenames/directories but that occurs during string formatting rather than after extraction and I wanted it to be a keyword so that it's included in the infojson like in yt-dlp.

I'm not sure how to handle the testcases though, since it's dynamic.