### PR TITLE
Optimize bencode for interpreters other than CPython

### DIFF
--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -22,17 +22,18 @@ import itertools
 import urllib.parse
 from http.cookiejar import Cookie
 from email.utils import mktime_tz, parsedate_tz
+from collections import deque
 from . import text, exception
 
 
 def bencode(num, alphabet="0123456789"):
     """Encode an integer into a base-N encoded string"""
-    data = ""
+    data_list = deque([])
     base = len(alphabet)
     while num:
         num, remainder = divmod(num, base)
-        data = alphabet[remainder] + data
-    return data
+        data_list.appendleft(alphabet[remainder])
+    return ''.join(data_list)
 
 
 def bdecode(data, alphabet="0123456789"):


### PR DESCRIPTION
I'm in the process of building a dynamic analysis tool for python. While running the tool on this repository I noticed a possible optimization regarding `bencode`.

The proposed changes are in line with [PEP-008](https://peps.python.org/pep-0008/#programming-recommendations). Interpreters other than CPython are sometimes not optimized for efficient string concatenation. The changes replace the concatenation by a deque, prepending to a normal list would still be inefficient. Testcases for `bencode` are already part of the testsuite.