### PR TITLE
Fix rare ExHentai duplicated metadata bug

### DIFF
--- a/gallery_dl/extractor/exhentai.py
+++ b/gallery_dl/extractor/exhentai.py
@@ -222,7 +222,7 @@ class ExhentaiGalleryExtractor(ExhentaiExtractor):
                 data["_http_validate"] = _validate_response
             else:
                 data["_http_validate"] = None
-            yield Message.Url, url, data.copy()
+            yield Message.Url, url, data
 
     def _items_hitomi(self):
         if self.config("metadata", False):

--- a/gallery_dl/extractor/exhentai.py
+++ b/gallery_dl/extractor/exhentai.py
@@ -222,7 +222,7 @@ class ExhentaiGalleryExtractor(ExhentaiExtractor):
                 data["_http_validate"] = _validate_response
             else:
                 data["_http_validate"] = None
-            yield Message.Url, url, data
+            yield Message.Url, url, data.copy()
 
     def _items_hitomi(self):
         if self.config("metadata", False):

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -697,7 +697,7 @@ class DataJob(Job):
         self.ascii = config.get(("output",), "ascii", ensure_ascii)
 
         private = config.get(("output",), "private")
-        self.filter = util.identity if private else util.filter_dict
+        self.filter = dict.copy if private else util.filter_dict
 
     def run(self):
         extractor = self.extractor


### PR DESCRIPTION
I'm using gallery-dl as a library and I've created a custom job for metadata extraction, similar to `DataJob`. But I was getting identical metadata for different pages on ExHentai. Digging a bit deeper, here's what I've found.

`ExhentaiGalleryExtractor.items` yields the same object for each image in a gallery. This causes problems when the object is not immediately used.

To reproduce:

```bash
gallery-dl --dump-json https://e-hentai.org/g/2346908/ab876a4073/ -o output.private=true
```
`-o output.private=true` causes image `kwdict` to be passed through `util.identity` in `DataJob.handle_url`:

https://github.com/mikf/gallery-dl/blob/560f7b41d80a07d6f711ede2246524ab064d38a1/gallery_dl/job.py#L700
https://github.com/mikf/gallery-dl/blob/560f7b41d80a07d6f711ede2246524ab064d38a1/gallery_dl/job.py#L734-L735

Since `util.identity` doesn't have a side-effect of creating a new dictionary like `util.filter_dict`, and since `DataJob` doesn't use the objects immediately, this triggers the bug.