### PR TITLE
[postprocessor:metadata] write version info to metadata files

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3702,6 +3702,17 @@ Description
     *not* be able to set its file's modification time unless an ``mtime``
     post processor with ``"event": "post"`` runs *before* it.
 
+metadata.version
+--------------
+Type
+    ``bool``
+Default
+    ``true``
+Description
+    Output version info (``version``, ``current_git_head`` and 
+    ``is_executable``) in addition to normal metadata.
+    This option has no effect if ``metadata.mode`` is not ``JSON``.
+
 
 mtime.event
 -----------

--- a/gallery_dl/__init__.py
+++ b/gallery_dl/__init__.py
@@ -118,25 +118,13 @@ def main():
             config.set(("output",), "mode", "null")
         elif args.loglevel <= logging.DEBUG:
             import platform
-            import subprocess
-            import os.path
             import requests
 
             extra = ""
             if getattr(sys, "frozen", False):
                 extra = " - Executable"
-            else:
-                try:
-                    out, err = subprocess.Popen(
-                        ("git", "rev-parse", "--short", "HEAD"),
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        cwd=os.path.dirname(os.path.abspath(__file__)),
-                    ).communicate()
-                    if out and not err:
-                        extra = " - Git HEAD: " + out.decode().rstrip()
-                except (OSError, subprocess.SubprocessError):
-                    pass
+            elif version.current_git_head():
+                extra = " - Git HEAD: " + version.current_git_head()
 
             log.debug("Version %s%s", __version__, extra)
             log.debug("Python %s - %s",

--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -204,8 +204,8 @@ class MetadataPP(PostProcessor):
             is_executable = getattr(sys, "frozen", False)
             kwdict_copy.update({
                 "_version": {
-                    "version": version.__version__,
-                    "is_executable": is_executable,
+                    "version"         : version.__version__,
+                    "is_executable"   : is_executable,
                     "current_git_head": None if is_executable else version.current_git_head()
                 }
             })

--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -206,7 +206,8 @@ class MetadataPP(PostProcessor):
                 "_version": {
                     "version"         : version.__version__,
                     "is_executable"   : is_executable,
-                    "current_git_head": None if is_executable else version.current_git_head()
+                    "current_git_head": None if is_executable
+                    else version.current_git_head()
                 }
             })
         util.dump_json(kwdict_copy, fp, self.ascii, self.indent)

--- a/gallery_dl/version.py
+++ b/gallery_dl/version.py
@@ -12,6 +12,7 @@ from . import cache
 import subprocess
 import os
 
+
 @cache.memcache()
 def current_git_head():
     try:
@@ -22,7 +23,7 @@ def current_git_head():
             cwd=os.path.dirname(os.path.abspath(__file__)),
         ).communicate()
         if out and not err:
-           return out.decode().rstrip()
+            return out.decode().rstrip()
         return None
     except (OSError, subprocess.SubprocessError):
         return None

--- a/gallery_dl/version.py
+++ b/gallery_dl/version.py
@@ -7,3 +7,22 @@
 # published by the Free Software Foundation.
 
 __version__ = "1.23.3"
+
+from . import cache
+import subprocess
+import os
+
+@cache.memcache()
+def current_git_head():
+    try:
+        out, err = subprocess.Popen(
+            ("git", "rev-parse", "--short", "HEAD"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        ).communicate()
+        if out and not err:
+           return out.decode().rstrip()
+        return None
+    except (OSError, subprocess.SubprocessError):
+        return None


### PR DESCRIPTION
This PR allows writing gallery-dl version info to metadata files. It is enabled by default, but can be turned off by setting `metadata.version` to `false`. This is primarily useful for debugging purposes (e.g. the user finds errors in older downloads and would like to write a script to automatically detect and correct them).

This feature is inspired by a similar one implemented in yt-dlp a while ago: https://github.com/yt-dlp/yt-dlp/commit/b5e7a2e69d94d68d47586452e6014e03cf2a2805

I'm not quite sure if it's a good idea to put code in `version.py` but putting it in `util.py` would introduce circular `import` statements which I'm not a big fan of.

Edit: clarity