### PR TITLE
add support for aibooru (using danbooru extractor)

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -971,6 +971,12 @@ Consider all sites to be NSFW unless otherwise known.
     <td>Pools, Popular Images, Posts, Tag Searches</td>
     <td>Supported</td>
 </tr>
+<tr>
+    <td>Aibooru</td>
+    <td>https://aibooru.online/</td>
+    <td>Favorites, Pools, Popular Images, Posts, Tag Searches</td>
+    <td></td>
+</tr>
 
 <tr>
     <td colspan="4"><strong>Gelbooru Beta 0.1.11</strong></td>

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -102,7 +102,7 @@ class DanbooruExtractor(BaseExtractor):
                 resp = self.request(template.format(self.root, post["id"]))
                 post.update(resp.json())
 
-            if self.root and url.startswith("/"):
+            if url[0] == "/":
                 url = self.root + url
 
             post.update(data)
@@ -209,6 +209,11 @@ class DanbooruTagExtractor(DanbooruExtractor):
         ("https://booru.allthefallen.moe/posts?tags=yume_shokunin", {
             "count": 12,
         }),
+        ("https://aibooru.online/posts?tags=center_frills&z=1", {
+            "pattern": r"https://aibooru\.online/data/original"
+                       r"/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{32}\.\w+",
+            "count": ">= 3",
+        }),
         ("https://hijiribe.donmai.us/posts?tags=bonocho"),
         ("https://sonohara.donmai.us/posts?tags=bonocho"),
         ("https://safebooru.donmai.us/posts?tags=bonocho"),
@@ -245,6 +250,7 @@ class DanbooruPoolExtractor(DanbooruExtractor):
             "url": "902549ffcdb00fe033c3f63e12bc3cb95c5fd8d5",
             "count": 6,
         }),
+        ("https://aibooru.online/pools/1"),
         ("https://danbooru.donmai.us/pool/show/7659"),
         ("https://e621.net/pool/show/73"),
     )
@@ -307,6 +313,9 @@ class DanbooruPostExtractor(DanbooruExtractor):
         ("https://booru.allthefallen.moe/posts/22", {
             "content": "21dda68e1d7e0a554078e62923f537d8e895cac8",
         }),
+        ("https://aibooru.online/posts/1", {
+            "content": "54d548743cd67799a62c77cbae97cfa0fec1b7e9",
+        }),
         ("https://danbooru.donmai.us/post/show/294929"),
         ("https://e621.net/post/show/535"),
     )
@@ -341,6 +350,7 @@ class DanbooruPopularExtractor(DanbooruExtractor):
             "count": ">= 70",
         }),
         ("https://booru.allthefallen.moe/explore/posts/popular"),
+        ("https://aibooru.online/explore/posts/popular"),
     )
 
     def __init__(self, match):

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -102,6 +102,9 @@ class DanbooruExtractor(BaseExtractor):
                 resp = self.request(template.format(self.root, post["id"]))
                 post.update(resp.json())
 
+            if self.root and url.startswith("/"):
+                url = self.root + url
+
             post.update(data)
             yield Message.Directory, post
             yield Message.Url, url, post
@@ -170,6 +173,10 @@ INSTANCES = {
         "pattern": r"booru\.allthefallen\.moe",
         "page-limit": 5000,
     },
+    "aibooru": {
+        "root": "https://aibooru.online",
+        "pattern": r"aibooru\.online",
+    }
 }
 
 BASE_PATTERN = DanbooruExtractor.update(INSTANCES)

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -324,7 +324,7 @@ def setup_test_config():
 
     for category in ("danbooru", "instagram", "twitter", "subscribestar",
                      "e621", "atfbooru", "inkbunny", "tapas", "pillowfort",
-                     "mangadex"):
+                     "mangadex", "aibooru"):
         config.set(("extractor", category), "username", None)
 
     config.set(("extractor", "mastodon.social"), "access-token",


### PR DESCRIPTION
Adds support for aibooru.online, a danbooru-based site.

One difference from the main danbooru site is that for whatever reason, aibooru returns relative URLs, e.g.
on danbooru you have in `post`:
'file_url': 'https://cdn.donmai.us/original/3c/1a/3c1a2a04a6060c497b714b9007a8331f.png'
while on `aibooru`:
'file_url': '/data/original/0c/54/0c540b58dc26913e77d86e318b0552d4.png'
The added check aims to detect and fix this situation.