### PR TITLE
[redgifs] fix 'token' extraction

### DIFF
--- a/gallery_dl/extractor/redgifs.py
+++ b/gallery_dl/extractor/redgifs.py
@@ -173,13 +173,7 @@ class RedgifsAPI():
     @cache(maxage=3600)
     def _fetch_bearer_token(self, extr):
         extr.log.debug("Retrieving Bearer token")
-
-        page = extr.request(extr.root + "/").text
-        index = text.extract(page, "/assets/js/index", ".js")[0]
-
-        url = extr.root + "/assets/js/index" + index + ".js"
-        page = extr.request(url, encoding="utf-8").text
-        token = "ey" + text.extract(page, '="ey', '"')[0]
-
+        token = extr.request(
+            self.API_ROOT + "/v2/auth/temporary").json()["token"]
         extr.log.debug("Token: '%s'", token)
         return token


### PR DESCRIPTION
Closes #3080 

https://github.com/Redgifs/api/wiki/Temporary-tokens

``` javascript
if (g instanceof FormData || g instanceof URLSearchParams || m.append('Content-Type', 'application/json'), !u) {
    const e = l || await Object(n['f'])();
    if (e) m.append('Authorization', 'Bearer ' + e);
    else {
        const e = await this.getTemporaryToken();
        e && m.append('Authorization', 'Bearer ' + e)
    }
}
````

``` javascript
async getTemporaryToken() {
    if (!this.temporaryToken) {
        const e = await this._request('GET', '/v2/auth/temporary', {
        }, {
            anon: !0
        });
        this.temporaryToken = e.token,
            console.debug('[auth] temporary token updated = ' + this.temporaryToken)
    }
    return this.temporaryToken
}
```