### PR TITLE
[vichan] recognize board url w/o trailing slash

### DIFF
--- a/gallery_dl/extractor/vichan.py
+++ b/gallery_dl/extractor/vichan.py
@@ -122,7 +122,7 @@ class VichanThreadExtractor(VichanExtractor):
 class VichanBoardExtractor(VichanExtractor):
     """Extractor for vichan boards"""
     subcategory = "board"
-    pattern = BASE_PATTERN + r"/([^/?#]+)(?:/index|/catalog|/\d+|/$)?"
+    pattern = BASE_PATTERN + r"/([^/?#]+)(?:/index|/catalog|/\d+|/?$)"
     test = (
         ("https://8kun.top/v/index.html", {
             "pattern": VichanThreadExtractor.pattern,

--- a/gallery_dl/extractor/vichan.py
+++ b/gallery_dl/extractor/vichan.py
@@ -122,7 +122,7 @@ class VichanThreadExtractor(VichanExtractor):
 class VichanBoardExtractor(VichanExtractor):
     """Extractor for vichan boards"""
     subcategory = "board"
-    pattern = BASE_PATTERN + r"/([^/?#]+)/(?:index|catalog|\d+|$)"
+    pattern = BASE_PATTERN + r"/([^/?#]+)(?:/index|/catalog|/\d+|/$)?"
     test = (
         ("https://8kun.top/v/index.html", {
             "pattern": VichanThreadExtractor.pattern,
@@ -138,7 +138,7 @@ class VichanBoardExtractor(VichanExtractor):
         ("https://wikieat.club/cel/catalog.html"),
         ("https://wikieat.club/cel/2.html"),
 
-        ("https://smuglo.li/a/", {
+        ("https://smuglo.li/a", {
             "pattern": VichanThreadExtractor.pattern,
             "count": ">= 100",
         }),


### PR DESCRIPTION
``` bash
$ py -m gallery_dl -s https://smugloli.net/a
[gallery-dl][error] No suitable extractor found for 'https://smugloli.net/a'
```