### PR TITLE
[instagram] Fix AttributeError on user stories extraction

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -500,6 +500,7 @@ class InstagramStoriesExtractor(InstagramExtractor):
 
     def __init__(self, match):
         h1, self.user, m1, h2, m2 = match.groups()
+        self.highlight_id = None
         if not self.user:
             self.subcategory = InstagramHighlightsExtractor.subcategory
             self.highlight_id = ("highlight:" + h1 if h1 else

--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -500,11 +500,14 @@ class InstagramStoriesExtractor(InstagramExtractor):
 
     def __init__(self, match):
         h1, self.user, m1, h2, m2 = match.groups()
-        self.highlight_id = None
-        if not self.user:
+
+        if self.user:
+            self.highlight_id = None
+        else:
             self.subcategory = InstagramHighlightsExtractor.subcategory
             self.highlight_id = ("highlight:" + h1 if h1 else
                                  binascii.a2b_base64(h2).decode())
+
         self.media_id = m1 or m2
         InstagramExtractor.__init__(self, match)
 


### PR DESCRIPTION
#3076 inadvertently introduced an AttributeError on extracting URLs like `https://www.instagram.com/stories/<username>`. This PR defaults the attribute to `None`.