### PR TITLE
Adding option to not output skipped files

### DIFF
--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -358,7 +358,8 @@ class DownloadJob(Job):
 
     def handle_skip(self):
         pathfmt = self.pathfmt
-        self.out.skip(pathfmt.path)
+        if not config.get(("output",), "quiet_skip", False):
+            self.out.skip(pathfmt.path)
         if "skip" in self.hooks:
             for callback in self.hooks["skip"]:
                 callback(pathfmt)

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -157,6 +157,12 @@ def build_parser():
         help="Print various debugging information",
     )
     output.add_argument(
+        "--quiet-skipped",
+        dest="quiet_skip",
+        action="store_true",
+        help="Don't print skipped files",
+    )
+    output.add_argument(
         "-g", "--get-urls",
         dest="list_urls", action="count",
         help="Print URLs instead of downloading",


### PR DESCRIPTION
This adds a `--quiet-skipped` output option to not output anything for skipped files.