### PR TITLE
[pixiv] rankings: add support for the new daily AI and daily AI R18 lists

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -479,6 +479,8 @@ class PixivRankingExtractor(PixivExtractor):
         mode_map = {
             "daily": "day",
             "daily_r18": "day_r18",
+            "daily_ai": "day_ai",
+            "daily_r18_ai": "day_r18_ai",
             "weekly": "week",
             "weekly_r18": "week_r18",
             "monthly": "month",


### PR DESCRIPTION
title says it all.

btw, i think it might be better to error out if the mode is not found in mode_map instead of falling back to daily as default. caught me offguard for a moment when i thought this new ranking mode just works when it was just downloading the daily ranking (yea, should have checked the logs and noticed the warning though...)