### PR TITLE
[pixiv] rankings: add support for the new daily AI and daily AI R18 lists

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -479,6 +479,8 @@ class PixivRankingExtractor(PixivExtractor):
         mode_map = {
             "daily": "day",
             "daily_r18": "day_r18",
+            "daily_ai": "day_ai",
+            "daily_r18_ai": "day_r18_ai",
             "weekly": "week",
             "weekly_r18": "week_r18",
             "monthly": "month",


### PR DESCRIPTION
title says it all.

btw first i didn't notice AI rankings weren't working, only later when i saw that it downloaded the "daily" ranking instead (yea i should have checked the logs for warnings). maybe a hard error in case of unrecognized mode would be better?

ps. if you think you've seen this PR before, it's because my previous account got banned by github, so the older PR with the same content got hidden