### PR TITLE
[hitomi] applying avif check for every image (#3030)

### DIFF
--- a/gallery_dl/extractor/hitomi.py
+++ b/gallery_dl/extractor/hitomi.py
@@ -113,20 +113,19 @@ class HitomiGalleryExtractor(GalleryExtractor):
         # see https://ltn.hitomi.la/gg.js
         gg_m, gg_b, gg_default = _parse_gg(self)
 
-        fmt_init = self.config("format") or "webp"
-
-        if fmt_init == "original":
-            subdomain, fmt, ext, check = "b", "images", None, False
+        fmt = self.config("format") or "webp"
+        if fmt == "original":
+            subdomain, path, ext, check = "b", "images", None, False
         else:
-            subdomain, ext, check = "a", fmt_init, True
+            subdomain, path, ext, check = "a", fmt, fmt, (fmt != "webp")
 
         result = []
         for image in self.info["files"]:
             if check:
-                if image.get("hasavif") and fmt_init != "webp":
-                    fmt = ext = "avif"
+                if image.get("has" + fmt):
+                    path = ext = fmt
                 else:
-                    fmt = ext = "webp"
+                    path = ext = "webp"
             ihash = image["hash"]
             idata = text.nameext_from_url(image["name"])
             if ext:
@@ -136,7 +135,7 @@ class HitomiGalleryExtractor(GalleryExtractor):
             inum = int(ihash[-1] + ihash[-3:-1], 16)
             url = "https://{}{}.hitomi.la/{}/{}/{}/{}.{}".format(
                 chr(97 + gg_m.get(inum, gg_default)),
-                subdomain, fmt, gg_b, inum, ihash, idata["extension"],
+                subdomain, path, gg_b, inum, ihash, idata["extension"],
             )
             result.append((url, idata))
         return result

--- a/gallery_dl/extractor/hitomi.py
+++ b/gallery_dl/extractor/hitomi.py
@@ -16,6 +16,7 @@ import string
 import json
 import re
 
+
 class HitomiGalleryExtractor(GalleryExtractor):
     """Extractor for image galleries from hitomi.la"""
     category = "hitomi"
@@ -107,7 +108,7 @@ class HitomiGalleryExtractor(GalleryExtractor):
             "parody"    : [o["parody"] for o in iget("parodys") or ()],
             "characters": [o["character"] for o in iget("characters") or ()]
         }
-    
+
     def images(self, _):
         # see https://ltn.hitomi.la/gg.js
         gg_m, gg_b, gg_default = _parse_gg(self)

--- a/gallery_dl/extractor/hitomi.py
+++ b/gallery_dl/extractor/hitomi.py
@@ -16,7 +16,6 @@ import string
 import json
 import re
 
-
 class HitomiGalleryExtractor(GalleryExtractor):
     """Extractor for image galleries from hitomi.la"""
     category = "hitomi"
@@ -108,23 +107,25 @@ class HitomiGalleryExtractor(GalleryExtractor):
             "parody"    : [o["parody"] for o in iget("parodys") or ()],
             "characters": [o["character"] for o in iget("characters") or ()]
         }
-
+    
     def images(self, _):
         # see https://ltn.hitomi.la/gg.js
         gg_m, gg_b, gg_default = _parse_gg(self)
 
-        fmt = self.config("format") or "webp"
-        if fmt == "original":
+        fmt_init = self.config("format") or "webp"
+
+        if fmt_init == "original":
             subdomain, fmt, ext, check = "b", "images", None, False
         else:
-            subdomain, ext, check = "a", fmt, True
+            subdomain, ext, check = "a", fmt_init, True
 
         result = []
         for image in self.info["files"]:
             if check:
-                if not image.get("has" + fmt):
+                if image.get("hasavif") and fmt_init != "webp":
+                    fmt = ext = "avif"
+                else:
                     fmt = ext = "webp"
-                check = False
             ihash = image["hash"]
             idata = text.nameext_from_url(image["name"])
             if ext:


### PR DESCRIPTION
A webp fallback was introduced after I made aware of it in a github issue, but it does not check every image. As an example, an image sequence like `avif, webp, avif, webp, webp, avif`, would download incorrectly, or rather, skip all webp due to broken links. The first image is avif, it passes and then tries to download everything as avif, but avif does not exist for every image. An avif property check for every image is needed, since not all files have the same file format in one gallery.