### PR TITLE
[hotleak] update for cloudflare challenge

### DIFF
--- a/gallery_dl/extractor/hotleak.py
+++ b/gallery_dl/extractor/hotleak.py
@@ -9,20 +9,22 @@
 from .common import Extractor, Message
 from .. import text, exception
 
-BASE_PATTERN = r"(?:https?://)?(?:www\.)?hotleak\.vip"
-
 
 class HotleakExtractor(Extractor):
     """Base class for hotleak extractors"""
     category = "hotleak"
-    directory_fmt = ("{category}", "{creator}",)
+    directory_fmt = ("{category}", "{creator}")
     filename_fmt = "{creator}_{id}.{extension}"
     archive_fmt = "{type}_{creator}_{id}"
     root = "https://hotleak.vip"
+    cookiedomain = ".hotleak.vip"
 
     def __init__(self, match):
         Extractor.__init__(self, match)
         self.session.headers["Referer"] = self.root
+        self.session.headers["User-Agent"] = self.config("user-agent") or \
+            ("Mozilla/5.0 (Windows NT 10.0; Win64; x64; "
+             "rv:106.0) Gecko/20100101 Firefox/106.0")
 
     def items(self):
         for post in self.posts():
@@ -33,26 +35,25 @@ class HotleakExtractor(Extractor):
         """Return an iterable containing relevant posts"""
         return ()
 
-    def _pagination(self, url, params):
-        params = text.parse_query(params)
+    def _pagination(self, url):
+        params = text.parse_query(self.params)
         params["page"] = text.parse_int(params.get("page"), 1)
 
         while True:
             page = self.request(url, params=params).text
             if "</article>" not in page:
                 return
-
             for item in text.extract_iter(
                     page, '<article class="movie-item', '</article>'):
                 yield text.extr(item, '<a href="', '"')
-
             params["page"] += 1
 
 
 class HotleakPostExtractor(HotleakExtractor):
     """Extractor for individual posts on hotleak"""
     subcategory = "post"
-    pattern = (BASE_PATTERN + r"/(?!hot|creators|videos|photos)"
+    pattern = (r"(?:https?://)?(?:www\.)?hotleak\.vip"
+               r"/(?!hot|creators|videos|photos)"
                r"([^/]+)/(photo|video)/(\d+)")
     test = (
         ("https://hotleak.vip/kaiyakawaii/photo/1617145", {
@@ -67,8 +68,8 @@ class HotleakPostExtractor(HotleakExtractor):
             },
         }),
         ("https://hotleak.vip/lilmochidoll/video/1625538", {
-            "pattern": r"ytdl:https://cdn8-leak\.camhdxx\.com"
-                       r"/1661/1625538/index\.m3u8",
+            "pattern": r"ytdl:https://cdn15-leak\.camhdxx\.com"
+                       r"/[^/]+/1661/1625538/index\.m3u8",
             "keyword": {
                 "id": 1625538,
                 "creator": "lilmochidoll",
@@ -86,15 +87,13 @@ class HotleakPostExtractor(HotleakExtractor):
     def posts(self):
         url = "{}/{}/{}/{}".format(
             self.root, self.creator, self.type, self.id)
-        page = self.request(url).text
         page = text.extr(
-            page, '<div class="movie-image thumb">', '</article>')
+            self.request(url).text, 'class="movie-image thumb">', '</article>')
         data = {
             "id"     : text.parse_int(self.id),
             "creator": self.creator,
             "type"   : self.type,
         }
-
         if self.type == "photo":
             data["url"] = text.extr(page, 'data-src="', '"')
             text.nameext_from_url(data["url"], data)
@@ -104,21 +103,22 @@ class HotleakPostExtractor(HotleakExtractor):
                 text.unescape(page), '"src":"', '"')
             text.nameext_from_url(data["url"], data)
             data["extension"] = "mp4"
-
         return (data,)
 
 
 class HotleakCreatorExtractor(HotleakExtractor):
     """Extractor for all posts from a hotleak creator"""
     subcategory = "creator"
-    pattern = BASE_PATTERN + r"/(?!hot|creators|videos|photos)([^/?#]+)/?$"
+    pattern = (r"(?:https?://)?(?:www\.)?hotleak\.vip"
+               r"/(?!hot|creators|videos|photos)([^/?#]+)/?$")
     test = (
         ("https://hotleak.vip/kaiyakawaii", {
-            "range": "1-200",
-            "count": 200,
+            "range": "1-50",
+            "count": 50,
         }),
         ("https://hotleak.vip/stellaviolet", {
-            "count": "> 600"
+            "range": "1-50",
+            "count": 50,
         }),
         ("https://hotleak.vip/doesnotexist", {
             "exception": exception.NotFoundError,
@@ -134,27 +134,22 @@ class HotleakCreatorExtractor(HotleakExtractor):
         return self._pagination(url)
 
     def _pagination(self, url):
-        headers = {"X-Requested-With": "XMLHttpRequest"}
+        self.session.headers["X-Requested-With"] = "XMLHttpRequest"
         params = {"page": 1}
 
         while True:
-            try:
-                response = self.request(
-                    url, headers=headers, params=params, notfound="creator")
-            except exception.HttpError as exc:
-                if exc.response.status_code == 429:
-                    self.wait(
-                        until=exc.response.headers.get("X-RateLimit-Reset"))
-                    continue
+            response = self.request(url, params=params, notfound="creator")
+            if response.status_code == 429:
+                self.wait(
+                    until=response.headers.get("X-RateLimit-Reset"))
+                continue
 
             posts = response.json()
             if not posts:
                 return
-
             data = {"creator": self.creator}
             for post in posts:
                 data["id"] = text.parse_int(post["id"])
-
                 if post["type"] == 0:
                     data["type"] = "photo"
                     data["url"] = self.root + "/storage/" + post["image"]
@@ -165,7 +160,6 @@ class HotleakCreatorExtractor(HotleakExtractor):
                     data["url"] = "ytdl:" + post["stream_url_play"]
                     text.nameext_from_url(data["url"], data)
                     data["extension"] = "mp4"
-
                 yield data
             params["page"] += 1
 
@@ -173,18 +167,19 @@ class HotleakCreatorExtractor(HotleakExtractor):
 class HotleakCategoryExtractor(HotleakExtractor):
     """Extractor for hotleak categories"""
     subcategory = "category"
-    pattern = BASE_PATTERN + r"/(hot|creators|videos|photos)(?:/?\?([^#]+))?"
+    pattern = (r"(?:https?://)?(?:www\.)?hotleak\.vip"
+               r"/(hot|creators|videos|photos)(?:/?\?([^#]+))?")
     test = (
         ("https://hotleak.vip/photos", {
             "pattern": HotleakPostExtractor.pattern,
-            "range": "1-50",
-            "count": 50,
+            "range": "1-10",
+            "count": 10,
         }),
         ("https://hotleak.vip/videos"),
         ("https://hotleak.vip/creators", {
             "pattern": HotleakCreatorExtractor.pattern,
-            "range": "1-50",
-            "count": 50,
+            "range": "1-10",
+            "count": 10,
         }),
         ("https://hotleak.vip/hot"),
     )
@@ -201,14 +196,14 @@ class HotleakCategoryExtractor(HotleakExtractor):
         elif self._category in ("videos", "photos"):
             data = {"_extractor": HotleakPostExtractor}
 
-        for item in self._pagination(url, self.params):
+        for item in self._pagination(url):
             yield Message.Queue, item, data
 
 
 class HotleakSearchExtractor(HotleakExtractor):
     """Extractor for hotleak search results"""
     subcategory = "search"
-    pattern = BASE_PATTERN + r"/search(?:/?\?([^#]+))"
+    pattern = r"(?:https?://)?(?:www\.)?hotleak\.vip/search(?:/?\?([^#]+))"
     test = (
         ("https://hotleak.vip/search?search=gallery-dl", {
             "count": 0,
@@ -224,5 +219,5 @@ class HotleakSearchExtractor(HotleakExtractor):
 
     def items(self):
         data = {"_extractor": HotleakCreatorExtractor}
-        for creator in self._pagination(self.root + "/search", self.params):
+        for creator in self._pagination(self.root + "/search"):
             yield Message.Queue, creator, data

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -338,6 +338,9 @@ def setup_test_config():
     config.set(("extractor", "deviantart"), "client-secret",
                "ff14994c744d9208e5caeec7aab4a026")
 
+    config.set(("extractor", "hotleak", "cookies"), "cf_clearance",
+               "6ULVJJ97U06FPx1bIXCIFWgP1cOz6Zet2DPg_rTnzJM-1669222952-0-150")
+
     config.set(("extractor", "tumblr"), "api-key",
                "0cXoHfIqVzMQcc3HESZSNsVlulGxEXGDTTZCDrRrjaa0jmuTc6")
     config.set(("extractor", "tumblr"), "api-secret",


### PR DESCRIPTION
closes #3288, #3293

- rejects the default 'user-agent' (Firefox/102.0 vs. Firefox/106.0)
- needs the 'cf_clearance' cookie (exp 1 year)
- update tests