### PR TITLE
[8muses] Add permalink + parts to album data

### DIFF
--- a/gallery_dl/extractor/8muses.py
+++ b/gallery_dl/extractor/8muses.py
@@ -119,10 +119,11 @@ class _8musesAlbumExtractor(Extractor):
         return {
             "id"     : album["id"],
             "path"   : album["path"],
-            "parts"  : album["permalink"].split('/'),
+            "parts"  : album["permalink"],
             "title"  : album["name"],
             "private": album["isPrivate"],
-            "url"    : self.root + album["permalink"],
+            "permalink" : album["permalink"],
+            "url"    : self.root + "/" + album["permalink"],
             "parent" : text.parse_int(album["parentId"]),
             "views"  : text.parse_int(album["numberViews"]),
             "likes"  : text.parse_int(album["numberLikes"]),

--- a/gallery_dl/extractor/8muses.py
+++ b/gallery_dl/extractor/8muses.py
@@ -119,6 +119,7 @@ class _8musesAlbumExtractor(Extractor):
         return {
             "id"     : album["id"],
             "path"   : album["path"],
+            "parts"  : album["permalink"].split('/'),
             "title"  : album["name"],
             "private": album["isPrivate"],
             "url"    : self.root + album["permalink"],


### PR DESCRIPTION
This fixes 8muses album URL formatting, and adds the permalink and its parts to the album object to improve directory formatting flexibility.

For example, this allows the following configurations to work. Using `/comics/album/Fakku-Comics/mogg/Liar` test URL:

```json5
{
    "extractor":
    {
        "8muses":
        {
            // Sets path-restrict to allow slashes in album data to create subdirectories (semi-unsafe)
            // Writes to: 8muses/Fakku-Comics/mogg/Liar
            "path-restrict": "\\\\|<>:\"?*",
            "directory": ["{category}", "{album[permalink]}"],
        },
        "8muses":
        {
            // Writes to: 8muses/Fakku-Comics/mogg/Liar
            "directory": ["{category}", "{album[parts][0]}", "{album[parts][1]}", "{album[parts][2]}"]
        },
        "8muses":
        {
            // Similar to default path but with a top-level artist/publisher directory
            // Writes to: 8muses/Fakku-Comics/Fakku Comics_mogg_Liar
            "directory": ["{category}", "{album[parts][0]}", "{album[path}"]
        }
    }
}
```