### PR TITLE
[deviantart] warn about potential private deviations at the end of pagination

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1307,22 +1307,34 @@ class DeviantartOAuthAPI():
             if unpack:
                 results = [item["journal"] for item in results
                            if "journal" in item]
-            if extend:
-                if public and len(results) < params["limit"]:
-                    if self.refresh_token_key:
-                        self.log.debug("Switching to private access token")
-                        public = False
-                        continue
-                    elif data["has_more"] and warn:
-                        warn = False
-                        self.log.warning(
-                            "Private deviations detected! Run 'gallery-dl "
-                            "oauth:deviantart' and follow the instructions to "
-                            "be able to access them.")
-                if self.metadata:
-                    self._metadata(results)
-                if self.folders:
-                    self._folders(results)
+
+            if extend and public and len(results) < params["limit"]:
+                if self.refresh_token_key:
+                    self.log.debug("Switching to private access token")
+                    public = False
+                    continue
+                elif data["has_more"] and warn:
+                    warn = False
+                    self.log.warning(
+                        "Private deviations detected! Run 'gallery-dl "
+                        "oauth:deviantart' and follow the instructions to "
+                        "be able to access them.")
+                # there's no way to tell if the last page contains private
+                # deviations or not
+                elif warn:
+                    warn = False
+                    self.log.warning(
+                        "The end of pagination has been reached, and "
+                        "gallery-dl cannot guarantee that there are no "
+                        "private deviations. Run 'gallery-dl oauth:deviantart'"
+                        " and follow the instructions to be able to access "
+                        "them.")
+
+            if extend and self.metadata:
+                self._metadata(results)
+            if extend and self.folders:
+                self._folders(results)
+
             yield from results
 
             if not data["has_more"] and (

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1308,27 +1308,21 @@ class DeviantartOAuthAPI():
                 results = [item["journal"] for item in results
                            if "journal" in item]
 
-            if extend and public and len(results) < params["limit"]:
-                if self.refresh_token_key:
-                    self.log.debug("Switching to private access token")
-                    public = False
-                    continue
-                elif data["has_more"] and warn:
-                    warn = False
-                    self.log.warning(
-                        "Private deviations detected! Run 'gallery-dl "
-                        "oauth:deviantart' and follow the instructions to "
-                        "be able to access them.")
+            has_private = extend and public and len(results) < params["limit"]
+            if has_private and self.refresh_token_key:
+                self.log.debug("Switching to private access token")
+                public = False
+                continue
+            elif has_private and warn:
+                warn = False
                 # there's no way to tell if the last page contains private
                 # deviations or not
-                elif warn:
-                    warn = False
-                    self.log.warning(
-                        "The end of pagination has been reached, and "
-                        "gallery-dl cannot guarantee that there are no "
-                        "private deviations. Run 'gallery-dl oauth:deviantart'"
-                        " and follow the instructions to be able to access "
-                        "them.")
+                msg = "Private deviations detected!" if data["has_more"] else \
+                    ("The end of pagination has been reached, and gallery-dl "
+                     "cannot guarantee that there are no private deviations.")
+                self.log.warning(
+                    msg + " Run 'gallery-dl oauth:deviantart' and follow the "
+                    "instructions to be able to access them.")
 
             if extend and self.metadata:
                 self._metadata(results)


### PR DESCRIPTION
Since gallery-dl detects private deviations by comparing `len(results)` to `params["limit"]`, private deviations that are in the last page will go undetected if a `refresh-token` is not configured, so I think gallery-dl should warn the user about this. I haven't encountered this issue in the wild, but I think it's a reasonable assumption.