### PR TITLE
[e621] implement manual pagination

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1004,18 +1004,21 @@ Description
     Note: This requires 1 additional HTTP request for each post.
 
 
-extractor.danbooru.pagination
------------------------------
+extractor.danbooru.threshold
+----------------------------
 Type
-    ``string``
+    ``string`` or ``int``
 Default
-    ``"length"``
+    ``"auto"``
 Description
-    Controls when to stop paginating over API results.
+    Stop paginating over API results if the length of a batch of returned
+    posts is less than the specified number. Defaults to the per-page limit
+    of the current instance, which is 320 for ``e621`` and 200 for
+    everything else.
 
-    * ``"length"``: Stop when the length of a batch of results is less than
-      the page limit.
-    * ``"manual"``: Only stop when a batch of results is empty.
+    Note: Changing this setting is normally not necessary. When the value is
+    greater than the per-page limit, gallery-dl will stop after the first
+    batch. The value cannot be less than 1.
 
 
 extractor.danbooru.ugoira

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1004,6 +1004,20 @@ Description
     Note: This requires 1 additional HTTP request for each post.
 
 
+extractor.danbooru.pagination
+-----------------------------
+Type
+    ``string``
+Default
+    ``"length"``
+Description
+    Controls when to stop paginating over API results.
+
+    * ``"length"``: Stop when the length of a batch of results is less than
+      the page limit.
+    * ``"manual"``: Only stop when a batch of results is empty.
+
+
 extractor.danbooru.ugoira
 -------------------------
 Type

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -41,7 +41,11 @@ class DanbooruExtractor(BaseExtractor):
         self.ugoira = self.config("ugoira", False)
         self.external = self.config("external", False)
         self.extended_metadata = self.config("metadata", False)
-        self.strategy = self.config("pagination", "length")
+        threshold = self.config("threshold")
+        if isinstance(threshold, int):
+            self.threshold = 1 if threshold < 1 else threshold
+        else:
+            self.threshold = self.per_page
 
         username, api_key = self._get_auth_info()
         if username:
@@ -118,7 +122,6 @@ class DanbooruExtractor(BaseExtractor):
 
     def _pagination(self, endpoint, params, pagenum=False):
         url = self.root + endpoint
-        limit = self.per_page if self.strategy == "length" else 1
         params["limit"] = self.per_page
         params["page"] = self.page_start
 
@@ -128,7 +131,7 @@ class DanbooruExtractor(BaseExtractor):
                 posts = posts["posts"]
             yield from posts
 
-            if len(posts) < limit:
+            if len(posts) < self.threshold:
                 return
 
             if pagenum:

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -118,6 +118,7 @@ class DanbooruExtractor(BaseExtractor):
 
     def _pagination(self, endpoint, params, pagenum=False):
         url = self.root + endpoint
+        limit = self.per_page if self.strategy == "length" else 1
         params["limit"] = self.per_page
         params["page"] = self.page_start
 
@@ -127,7 +128,7 @@ class DanbooruExtractor(BaseExtractor):
                 posts = posts["posts"]
             yield from posts
 
-            if self.strategy == "length" and len(posts) < self.per_page:
+            if len(posts) < limit:
                 return
 
             if pagenum:

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -41,6 +41,7 @@ class DanbooruExtractor(BaseExtractor):
         self.ugoira = self.config("ugoira", False)
         self.external = self.config("external", False)
         self.extended_metadata = self.config("metadata", False)
+        self.strategy = self.config("pagination", "length")
 
         username, api_key = self._get_auth_info()
         if username:
@@ -126,7 +127,7 @@ class DanbooruExtractor(BaseExtractor):
                 posts = posts["posts"]
             yield from posts
 
-            if len(posts) < self.per_page:
+            if self.strategy == "length" and len(posts) < self.per_page:
                 return
 
             if pagenum:


### PR DESCRIPTION
Sometimes the number of returned `post` objects is smaller than the per-page limit even though there are more posts. This causes gallery-dl to stop the pagination prematurely.

[Example JSON](https://e621.net/posts.json?tags=zootopia+rating%3Asafe+status%3Adeleted&limit=320)
The API returns 318 posts.

This only seems to apply to deleted posts. Not sure if other Danbooru instances are affected as well.