### PR TITLE
[sex.com] Download videos from cdn (#3408)

### DIFF
--- a/gallery_dl/extractor/sexcom.py
+++ b/gallery_dl/extractor/sexcom.py
@@ -74,9 +74,7 @@ class SexcomExtractor(Extractor):
                 path = text.extr(info, "src: '", "'")
                 data["filename"] = path.rpartition("/")[2]
                 data["extension"] = "mp4"
-                if "'HD'" in info:
-                    path += "/hd"
-                data["url"] = self.root + path
+                data["url"] = path
             else:
                 iframe = extr('<iframe', '>')
                 src = (text.extr(iframe, ' src="', '"') or


### PR DESCRIPTION
The format of video sources was changed recently to be a full URL with https:// in the beginning. The original extractor code appended the video source URL to root url of the website, thus yielding invalid url in format ...sex.comhttps... that failed to resolve.

Closes #3408 