### PR TITLE
[twitter] restore the text of truncated retweets

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -1273,10 +1273,15 @@ class TwitterAPI():
                         tweet = retweet
                     elif retweet:
                         tweet["author"] = users[retweet["user_id_str"]]
-                        if "extended_entities" in retweet and \
-                                "extended_entities" not in tweet:
-                            tweet["extended_entities"] = \
-                                retweet["extended_entities"]
+                        key = "extended_entities"
+                        if key in retweet and key not in tweet:
+                            tweet[key] = retweet[key]
+                        key = "full_text"
+                        if tweet[key][-1] == "…":
+                            match = re.match(r"^RT @\w{1,15}: ", tweet[key])
+                            if match:
+                                tweet[key] = match.group() + retweet[key]
+
                 tweet["user"] = users[tweet["user_id_str"]]
                 yield tweet
 

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -670,6 +670,17 @@ class TwitterTweetExtractor(TwitterExtractor):
                 "It’s our \\(Mystery\\) Gift to you, Trainers! \n\n❓🎁➡️ "
             )},
         }),
+        # truncated retweet
+        ("https://twitter.com/Aralyre/status/1603062622483537921", {
+            "options": (("retweets", True),),
+            "count": 1,
+            "keyword": {
+                "content"   : r"re:^RT @\w{1,15}: [^…]+$",
+                "tweet_id"  : 1603062622483537921,
+                "retweet_id": 1602715680662749184,
+                "date"      : "dt:2022-12-14 16:21:27",
+            },
+        }),
         # Reply to deleted tweet (#403, #838)
         ("https://twitter.com/i/web/status/1170041925560258560", {
             "pattern": r"https://pbs.twimg.com/media/EDzS7VrU0AAFL4_",
@@ -754,6 +765,7 @@ class TwitterTweetExtractor(TwitterExtractor):
             "options": (("retweets", "original"),),
             "count": 2,
             "keyword": {
+                "content"   : "",
                 "tweet_id"  : 1296296016002547713,
                 "retweet_id": 1296296016002547713,
                 "date"      : "dt:2020-08-20 04:00:28",

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -732,6 +732,13 @@ class TwitterTweetExtractor(TwitterExtractor):
             "pattern": r"https://video\.twimg\.com/amplify_video"
                        r"/1560607284333449216/vid/720x720/\w+\.mp4",
         }),
+        # unified_card video_app
+        ("https://twitter.com/poco_dandy/status/1150646424461176832", {
+            "options": (("cards", True),),
+            "pattern": r"https://video\.twimg\.com/amplify_video/\d+"
+                       r"/vid/\d+x\d+/\w+\.mp4",
+            "range": "2",
+        }),
         # unified_card without type
         ("https://twitter.com/i/web/status/1466183847628865544", {
             "count": 0,
@@ -783,9 +790,9 @@ class TwitterTweetExtractor(TwitterExtractor):
         # '?format=...&name=...'-style URLs
         ("https://twitter.com/poco_dandy/status/1150646424461176832", {
             "options": (("cards", True),),
-            "pattern": r"https://pbs.twimg.com/card_img/157\d+/[\w-]+"
+            "pattern": r"https://pbs\.twimg\.com/card_img/\d+/[\w-]+"
                        r"\?format=(jpg|png)&name=orig$",
-            "range": "1-2",
+            "range": "1",
         }),
     )
 


### PR DESCRIPTION
The text of retweets often gets truncated because Twitter prepends the original author's username to it:
```
RT @FireFox70456538: It's been a long time since I haven't shared any arts on Twitter...\nSo here I'm back with a nudity art I made of Ara,…
It's been a long time since I haven't shared any arts on Twitter...\nSo here I'm back with a nudity art I made of Ara, zona's of the well-known @Aralyre 😊
```
(taken from [here](https://twitter.com/Aralyre/status/1603062622483537921), warning: kind of NSFW)

This PR solves the issue by prepending the "prefix" to the text of the original tweet. I tried using `retweets=original` instead, but that would change a lot of the other fields and break my existing archive database.

The legacy pagination method needs more testing because the corresponding API endpoints never seemed to return any retweets for me.