### PR TITLE
[docs] Update links and fix field typo

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -588,7 +588,7 @@ Description
     data structure into metadata dictionaries as the given name.
 
     For example, setting this option to ``"gdl_path"`` would make it possible
-    to access the current file's filename as ``"[gdl_path.filename}"``.
+    to access the current file's filename as ``"{gdl_path.filename}"``.
 
 
 extractor.*.http-metadata
@@ -4468,9 +4468,9 @@ Description
           In addition to the default
           `LogRecord attributes <https://docs.python.org/3/library/logging.html#logrecord-attributes>`__,
           it is also possible to access the current
-          `extractor <https://github.com/mikf/gallery-dl/blob/33fe67b594dbf8fb742464c95e0f6952bb60eb8a/gallery_dl/extractor/common.py#L23>`__,
-          `job <https://github.com/mikf/gallery-dl/blob/33fe67b594dbf8fb742464c95e0f6952bb60eb8a/gallery_dl/job.py#L18>`__,
-          `path <https://github.com/mikf/gallery-dl/blob/33fe67b594dbf8fb742464c95e0f6952bb60eb8a/gallery_dl/util.py#L702>`__,
+          `extractor <https://github.com/mikf/gallery-dl/blob/9f06e79868eafb3d9747dde8ef3252ba5f4c0e23/gallery_dl/extractor/common.py#L26>`__,
+          `job <https://github.com/mikf/gallery-dl/blob/b14b33f19e6478c6bc6ac6b5a51c8b5cebf493f6/gallery_dl/job.py#L21>`__,
+          `path <https://github.com/mikf/gallery-dl/blob/master/gallery_dl/path.py#L27>`__,
           and `keywords` objects and their attributes, for example
           ``"{extractor.url}"``, ``"{path.filename}"``, ``"{keywords.title}"``
         * Default: ``"[{name}][{levelname}] {message}"``

--- a/gallery_dl/formatter.py
+++ b/gallery_dl/formatter.py
@@ -60,13 +60,20 @@ class StringFormatter():
     - "u": calls str.upper
     - "c": calls str.capitalize
     - "C": calls string.capwords
-    - "j". calls json.dumps
+    - "g": calls text.slugify()
+    - "j": calls json.dumps
     - "t": calls str.strip
+    - "T": calls util.datetime_to_timestamp_string()
     - "d": calls text.parse_timestamp
-    - "U": calls urllib.parse.unescape
+    - "s": calls str()
     - "S": calls util.to_string()
-    - "T": calls util.to_timestamü()
+    - "U": calls urllib.parse.unescape
+    - "r": calls repr()
+    - "a": calls ascii()
     - Example: {f!l} -> "example"; {f!u} -> "EXAMPLE"
+
+    # Go to _CONVERSIONS and _SPECIFIERS below to se all of them, read:
+    # https://github.com/mikf/gallery-dl/blob/master/docs/formatting.md
 
     Extra Format Specifiers:
     - "?<before>/<after>/":


### PR DESCRIPTION
No function changes.

Update links which refer to common.py, job.py and extractor.py to show correct line numbers.

Slighty update formatter.StringFormatter conversions docstring.