### PR TITLE
[twitter] implement `syndication=extended`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2655,11 +2655,18 @@ Description
 extractor.twitter.syndication
 -----------------------------
 Type
-    ``bool``
+    ``bool`` or ``string``
 Default
     ``false``
 Description
-    Retrieve age-restricted content using Twitter's syndication API.
+    Controls how to retrieve age-restricted content when not logged in.
+
+    * ``false``: Skip age-restricted Tweets.
+    * ``true``: Download using Twitter's syndication API.
+    * ``"extended"``: Try to fetch Tweet metadata using the normal API
+    in addition to the syndication API. This requires additional HTTP
+    requests in some cases (e.g. when `retweets <extractor.twitter.retweets_>`_
+    is enabled).
 
 
 extractor.twitter.logout

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2655,7 +2655,8 @@ Description
 extractor.twitter.syndication
 -----------------------------
 Type
-    ``bool`` or ``string``
+    * ``bool``
+    * ``string``
 Default
     ``false``
 Description
@@ -2664,9 +2665,9 @@ Description
     * ``false``: Skip age-restricted Tweets.
     * ``true``: Download using Twitter's syndication API.
     * ``"extended"``: Try to fetch Tweet metadata using the normal API
-    in addition to the syndication API. This requires additional HTTP
-    requests in some cases (e.g. when `retweets <extractor.twitter.retweets_>`_
-    is enabled).
+      in addition to the syndication API. This requires additional HTTP
+      requests in some cases (e.g. when `retweets <extractor.twitter.retweets_>`_
+      are enabled).
 
 
 extractor.twitter.logout

--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -298,10 +298,10 @@ class TwitterExtractor(Extractor):
         except KeyError:
             pass
 
-        # try to fetch extended user data
         if "legacy" in user:
             user = user["legacy"]
         elif "statuses_count" not in user and self.syndication == "extended":
+            # try to fetch extended user data
             user = self.api.user_by_screen_name(user["screen_name"])["legacy"]
 
         uget = user.get
@@ -995,6 +995,7 @@ class TwitterAPI():
         }
 
         self._nsfw_warning = True
+        self._syndication = self.extractor.syndication
         self._json_dumps = json.JSONEncoder(separators=(",", ":")).encode
 
         cookies = extractor.session.cookies
@@ -1497,7 +1498,7 @@ class TwitterAPI():
         tweet_id = entry["entryId"].rpartition("-")[2]
 
         if text.startswith("Age-restricted"):
-            if self.extractor.syndication:
+            if self._syndication:
                 return self._syndication_tweet(tweet_id)
             elif self._nsfw_warning:
                 self._nsfw_warning = False


### PR DESCRIPTION
The syndication API doesn't return as much metadata as the GraphQL API, so I've implemented `syndication=extended` to enable the user to optionally fetch user metadata using `user_by_screen_name`. This is mostly useful when used along with `conversations`, `retweets`, etc.