### PR TITLE
[myhentaigallery] handle whitespace before the title tag

### DIFF
--- a/gallery_dl/extractor/myhentaigallery.py
+++ b/gallery_dl/extractor/myhentaigallery.py
@@ -44,7 +44,10 @@ class MyhentaigalleryGalleryExtractor(GalleryExtractor):
         extr = text.extract_from(page)
         split = text.split_html
 
-        title = extr('<div class="comic-description">\n<h1>', '</h1>')
+        title = extr('<div class="comic-description">\n', '</h1>').lstrip()
+        if title.startswith("<h1>"):
+            title = title[len("<h1>"):]
+
         if not title:
             raise exception.NotFoundError("gallery")
 


### PR DESCRIPTION
There is for some reason a space before the `<h1>` tag on some pages, for example [this one](https://myhentaigallery.com/gallery/thumbnails/8901), which makes the extractor fail.