### PR TITLE
[generic] fix regex for non-src image URLs

### DIFF
--- a/gallery_dl/extractor/generic.py
+++ b/gallery_dl/extractor/generic.py
@@ -150,7 +150,7 @@ class GenericExtractor(Extractor):
         https://en.wikipedia.org/wiki/List_of_file_formats
 
         Compared to the "pattern" class variable, here we must exclude also
-        other special characters (space, ", ', >), since we are looking for
+        other special characters (space, ", ', <, >), since we are looking for
         urls in html tags.
         """
 
@@ -158,7 +158,7 @@ class GenericExtractor(Extractor):
             (?:[^?&#"'>\s]+)                    # anything until dot+extension
             \.(?:jpe?g|jpe|png|gif
                  |web[mp]|mp4|mkv|og[gmv]|opus) # dot + image/video extensions
-            (?:[^"'>\s]*)?                      # optional query and fragment
+            (?:[^"'<>\s]*)?                      # optional query and fragment
             """
 
         imageurls_src = re.findall(imageurl_pattern_src, page)


### PR DESCRIPTION
Trying something like `gallery-dl -g "generic:https://boards.4channel.org/vt/thread/41385493" --filter "re.match('(https://i\.4cdn\.org/vt/[0-9]+\.)|(https://(litter|files)\.catbox\.moe/)',imageurl)"`
you can see that the catbox URLs have some `<wb` trash at the end, caused by not stopping the regex match at `<` characters. This is an attempt to fix that.