### PR TITLE
[bunkr] Fix extracting mkv and ts files

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -75,7 +75,8 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
         headers = {"Referer": root.replace("://", "://stream.", 1) + "/"}
         for file in files:
             if file["file"].endswith(
-                    (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".zip", ".rar", ".7z")):
+                    (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".ts",
+                     ".zip", ".rar", ".7z")):
                 file["_http_headers"] = headers
                 file["file"] = file["file"].replace(
                     "://cdn", "://media-files", 1)

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -75,7 +75,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
         headers = {"Referer": root.replace("://", "://stream.", 1) + "/"}
         for file in files:
             if file["file"].endswith(
-                    (".mp4", ".m4v", ".mov", ".webm", ".zip", ".rar", ".7z")):
+                    (".mp4", ".m4v", ".mov", ".webm", ".mkv", ".zip", ".rar", ".7z")):
                 file["_http_headers"] = headers
                 file["file"] = file["file"].replace(
                     "://cdn", "://media-files", 1)


### PR DESCRIPTION
The bunkr extractor special cases a bunch of file extensions because bunkr itself has a streaming player for those extensions. Turns out mkv and ts files should also be included.