### PR TITLE
[pixiv] Fix tag write when tags setting is set to original

### DIFF
--- a/gallery_dl/postprocessor/metadata.py
+++ b/gallery_dl/postprocessor/metadata.py
@@ -184,6 +184,13 @@ class MetadataPP(PostProcessor):
             for taglist in taglists:
                 extend(taglist)
             tags.sort()
+        elif all(isinstance(e, dict) for e in tags):
+            taglists = tags
+            tags = []
+            extend = tags.extend
+            for tagdict in taglists:
+                extend([x for x in tagdict.values() if x is not None])
+            tags.sort()
 
         fp.write("\n".join(tags) + "\n")
 

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -287,7 +287,7 @@ class MetadataTest(BasePostprocessorTest):
             self._trigger()
         self.assertEqual(self._output(m), "foobar1\nfoobar2\nfoobarbaz\n")
 
-    def test_metadata_tags_array_of_dict(self):
+    def test_metadata_tags_list_of_dict(self):
         self._create(
             {"mode": "tags"},
             {"tags": [{"g": "foobar1", "m": "foobar2"}, {"g": None, "m": "foobarbaz"}]},

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -290,7 +290,10 @@ class MetadataTest(BasePostprocessorTest):
     def test_metadata_tags_list_of_dict(self):
         self._create(
             {"mode": "tags"},
-            {"tags": [{"g": "foobar1", "m": "foobar2"}, {"g": None, "m": "foobarbaz"}]},
+            {"tags": [
+                {"g": "foobar1", "m": "foobar2"},
+                {"g": None, "m": "foobarbaz"}
+            ]},
         )
         with patch("builtins.open", mock_open()) as m:
             self._trigger()

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -287,6 +287,15 @@ class MetadataTest(BasePostprocessorTest):
             self._trigger()
         self.assertEqual(self._output(m), "foobar1\nfoobar2\nfoobarbaz\n")
 
+    def test_metadata_tags_array_of_dict(self):
+        self._create(
+            {"mode": "tags"},
+            {"tags": [{"g": "foobar1", "m": "foobar2"}, {"g": None, "m": "foobarbaz"}]},
+        )
+        with patch("builtins.open", mock_open()) as m:
+            self._trigger()
+        self.assertEqual(self._output(m), "foobar1\nfoobar2\nfoobarbaz\n")
+
     def test_metadata_custom(self):
         def test(pp_info):
             pp = self._create(pp_info, {"foo": "bar"})


### PR DESCRIPTION
See this issue: https://github.com/mikf/gallery-dl/issues/3674

The following command will fail on current master:
`gallery-dl --ignore-config --write-tags --option "extractor.pixiv.tags=original" --verbose https://www.pixiv.net/en/artworks/105480642`

The traceback:
```
Traceback (most recent call last):
  File "/Users/gray/source/gallery-dl/gallery_dl/job.py", line 102, in run
    self.dispatch(msg)
  File "/Users/gray/source/gallery-dl/gallery_dl/job.py", line 146, in dispatch
    self.handle_url(url, kwdict)
  File "/Users/gray/source/gallery-dl/gallery_dl/job.py", line 297, in handle_url
    callback(pathfmt)
  File "/Users/gray/source/gallery-dl/gallery_dl/postprocessor/metadata.py", line 101, in run
    self.write(fp, pathfmt.kwdict)
  File "/Users/gray/source/gallery-dl/gallery_dl/postprocessor/metadata.py", line 188, in _write_tags
    fp.write("\n".join(tags) + "\n")
TypeError: sequence item 0: expected str instance, dict found
```
The issue:

```
> /Users/gray/source/gallery-dl/gallery_dl/postprocessor/metadata.py(198)_write_tags()
    197
--> 198         fp.write("\n".join(tags) + "\n")
    199

[asyncio][debug] Using selector: KqueueSelector
ipdb> tags
[{'name': 'バーチャルYouTuber', 'translated_name': 'Virtual Youtuber'}, {'name': 'VTuber', 'translated_name': 'virtual YouTuber'}, {'name': 'ホロライブ', 'translated_name': 'Hololive'}, {'name': 'hololive', 'translated_name': None}, {'name': 'holoX', 'translated_name': None}, {'name': '沙花叉クロヱ', 'translated_name': 'Sakamata Chloe'}, {'name': 'バーチャルYouTuber100users入り', 'translated_name': 'Virtual Youtuber 100+ bookmarks'}]
```

When the tags setting for Pixiv is set to original the tags are returned as a list of dict objects. The code that is bombing out expects tags to be list of str.

There is already branching logic to handle the different formats that tags come back as from the extractors so I've extended that logic to handle when tags come back as list of dict objects. As you can see sometimes the values are None so there is handling to remove those from the returned list as well.

This will make the list of tags written just a flat list of strings, loosing the mapping between Japanese tag and the translated version, but that is just how the file is. Ideally I think it would be great to have this change be in the Pixiv extractor but if I flatten out the mapping there, then we'll loose the mapping in that variable that is useful in other parts, such as the json metadata write.