### PR TITLE
[deviantart] don't attempt to log in when testing

### DIFF
--- a/test/test_results.py
+++ b/test/test_results.py
@@ -322,8 +322,8 @@ def setup_test_config():
     config.set(("extractor", "mangoxo")   , "username", "LiQiang3")
     config.set(("extractor", "mangoxo")   , "password", "5zbQF10_5u25259Ma")
 
-    for category in ("danbooru", "atfbooru", "aibooru", "e621", "e926",
-                     "instagram", "twitter", "subscribestar",
+    for category in ("danbooru", "deviantart", "atfbooru", "aibooru", "e621",
+                     "e926", "instagram", "twitter", "subscribestar",
                      "inkbunny", "tapas", "pillowfort", "mangadex"):
         config.set(("extractor", category), "username", None)
 


### PR DESCRIPTION
This fixes the following error when running `test_results.py`:
```
======================================================================
ERROR: test_DeviantartScrapsExtractor_1 (__main__.TestExtractorResults)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\programming\gallery-dl\test\test_results.py", line 357, in test
    self._run_test(extr, url, result)
  File "D:\programming\gallery-dl\test\test_results.py", line 72, in _run_test
    tjob.run()
  File "D:\programming\gallery-dl\test\test_results.py", line 198, in run
    for msg in self.extractor:
  File "D:\programming\gallery-dl\gallery_dl\extractor\deviantart.py", line 84, in items
    for deviation in self.deviations():
  File "D:\programming\gallery-dl\gallery_dl\extractor\deviantart.py", line 1119, in deviations
    self.login()
  File "D:\programming\gallery-dl\gallery_dl\extractor\deviantart.py", line 1137, in login
    self._update_cookies(_login_impl(self, username, password))
  File "D:\programming\gallery-dl\gallery_dl\cache.py", line 115, in __call__
    value = self.func(*args, **kwargs)
  File "D:\programming\gallery-dl\gallery_dl\extractor\deviantart.py", line 1715, in _login_impl
    raise exception.AuthenticationError()
gallery_dl.exception.AuthenticationError: Invalid or missing login credentials
```