### PR TITLE
Add szurubooru support

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4838,6 +4838,17 @@ How To
       and put them in your configuration file
       as ``"api-key"`` and ``"api-secret"``
 
+extractor.szurubooru.username & .token
+--------------------------------------
+Type
+    ``string``
+How To
+    * login and click your username on the top right
+    * click "create token"
+    * configure put your username in ``username`` and your newly created token in ``token``
+When To Use
+    By default, every user can access the read-only API so this should not be necessary.
+
 
 extractor.tumblr.api-key & .api-secret
 --------------------------------------

--- a/docs/gallery-dl-example.conf
+++ b/docs/gallery-dl-example.conf
@@ -93,7 +93,14 @@
             "username": "user",
             "password": "#secret#"
         },
-
+        "szurubooru":
+        {
+            "#": "This is usually optional; fill in if your szurubooru instance of choice doesn't support anonymous downloads",
+            "username": null,
+            "token": "30b22174-cd33-4c08-acd7-d2c9e8fb8542",
+            "#": "The amount of records to fetch with each search. Values too large will be shortened by the server.",
+            "page_size": 100
+        },
         "furaffinity": {
             "#": "authentication with username and password is not possible due to CAPTCHA",
             "cookies": {

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -294,6 +294,12 @@
             "username": null,
             "password": null
         },
+        "szurubooru":
+        {
+            "username": null,
+            "token": null,
+            "page_size": 40
+        },
         "tsumino":
         {
             "username": null,

--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -812,6 +812,12 @@ Consider all sites to be NSFW unless otherwise known.
     <td>Supported</td>
 </tr>
 <tr>
+    <td>Szurubooru</td>
+    <td>Various instances (<a href="https://github.com/rr-/szurubooru/">project</a>)</td>
+    <td>Search Results</td>
+    <td>Supported</td>
+</tr>
+<tr>
     <td>Tapas</td>
     <td>https://tapas.io/</td>
     <td>Episodes, Series</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -140,6 +140,7 @@ modules = [
     "soundgasm",
     "speakerdeck",
     "subscribestar",
+    "szurubooru",
     "tapas",
     "tcbscans",
     "telegraph",

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -8,13 +8,13 @@ import sys
 
 class SzurubooruExtractor(GalleryExtractor):
     """Extractor for szurubooru hosted boorus (https://github.com/rr-/szurubooru/)"""
-    auth_token: str | None = None
-    username: str | None = None
-    page_size: int = 40
+    auth_token = None
+    username = None
+    page_size = 40
 
-    specifies_protocol: bool = False
-    base_url: str | None = None
-    query: str | None = None
+    specifies_protocol = False
+    base_url = None
+    query = None
 
     pattern = r"((https?://)?[^/]+)/posts/query=([^#]*)"
     category = "szurubooru"
@@ -27,7 +27,7 @@ class SzurubooruExtractor(GalleryExtractor):
         "count": ">=1"
     })
 
-    def __init__(self, match: re.Match):
+    def __init__(self, match):
         super().__init__(match)
         self.auth_token = self.config("token")
         self.username = self.config("username")
@@ -83,7 +83,7 @@ class SzurubooruExtractor(GalleryExtractor):
 
         return headers
 
-    def _get_page(self, tags: str, headers: dict[str, str], offset: int = 0) -> dict:
+    def _get_page(self, tags, headers, offset = 0) -> dict:
         api_url = f'{self.base_url}/api/posts/?offset={offset}&limit={self.page_size}&query={tags}'
         api_result = self.request(api_url, headers=headers).json()
 

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -1,0 +1,94 @@
+import base64
+import re
+import urllib.parse
+
+from .common import Message, GalleryExtractor
+import sys
+
+
+class SzurubooruExtractor(GalleryExtractor):
+    """Extractor for szurubooru hosted boorus (https://github.com/rr-/szurubooru/)"""
+    auth_token: str | None = None
+    username: str | None = None
+    page_size: int = 40
+
+    specifies_protocol: bool = False
+    base_url: str | None = None
+    query: str | None = None
+
+    pattern = r"((https?://)?[^/]+)/posts/query=([^#]*)"
+    category = "szurubooru"
+    domain = "szurubooru"
+    directory_fmt = ("{domain}", "{query}")
+    filename_fmt = "{id}_{version}_{tags_str}.{extension}"
+
+    def __init__(self, match: re.Match):
+        super().__init__(match)
+        self.auth_token = self.config("token")
+        self.username = self.config("username")
+        self.base_url = match.group(1)
+        self.specifies_protocol = match.group(2) is not None
+        self.query = match.group(3)
+        self.domain = urllib.parse.urlparse(self.base_url).hostname
+
+        if self.config("page_size") is not None:
+            try:
+                self.page_size = int(self.config('page_size'))
+            except ValueError:
+                self.page_size = 40
+
+    def items(self):
+        headers = self._get_headers()
+
+        yield Message.Directory, {'domain': self.domain, 'query': self.query}, self.query
+
+        try:
+            offset = 0
+            while True:
+                page_content = self._get_page(self.query, headers=headers, offset=offset)
+
+                offset = page_content['offset']
+
+                for image_metadata in page_content['results']:
+                    yield Message.Url, image_metadata['contentUrl'], image_metadata
+
+                offset += len(page_content['results'])
+                if offset >= int(page_content['total']):
+                    break
+
+        except Exception as ex:
+            sys.stderr.write(ex.args[0])
+            sys.stderr.write("\n")
+            return
+
+    def _get_headers(self):
+        # https://github.com/rr-/szurubooru/blob/master/doc/API.md#basic-requests
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+
+        if self.auth_token is not None \
+                and self.username is not None \
+                and len(self.auth_token) > 0 and \
+                len(self.username) > 0:
+            # https://github.com/rr-/szurubooru/blob/master/doc/API.md#user-token-authentication
+            concatenation = f"{self.username}:{self.auth_token}".encode('ascii')
+            headers['Authorization'] = f'Token {base64.b64encode(concatenation).decode("ascii")}'
+
+        return headers
+
+    def _get_page(self, tags: str, headers: dict[str, str], offset: int = 0) -> dict:
+        api_url = f'{self.base_url}/api/posts/?offset={offset}&limit={self.page_size}&query={tags}'
+        api_result = self.request(api_url, headers=headers).json()
+
+        for error_tag in ['name', 'title', 'description']:
+            if error_tag in api_result:
+                raise Exception(f"{api_result['name']} while fetching data:"
+                                f" {api_result['title']} ({api_result['description']})")
+
+        for result in api_result['results']:
+            result['extension'] = result['contentUrl'].split('.')[-1]
+            result['tags_str'] = ','.join([tag['names'][0] for tag in result['tags']])[:250]
+
+        return api_result

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -89,7 +89,7 @@ class SzurubooruExtractor(GalleryExtractor):
             concatenation = concatenation.encode('ascii')
 
             b64token = base64.b64encode(concatenation).decode("ascii")
-            headers['Authorization'] = f'Token {b64token}'
+            headers['Authorization'] = 'Token ' + b64token
 
         return headers
 

--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -22,6 +22,11 @@ class SzurubooruExtractor(GalleryExtractor):
     directory_fmt = ("{domain}", "{query}")
     filename_fmt = "{id}_{version}_{tags_str}.{extension}"
 
+    test = ("https://booru.foalcon.com/posts/query=artist%5C%3Abobdude0", {
+        "pattern": r"https://booru.foalcon.com/data/posts/\d+.png",
+        "count": ">=1"
+    })
+
     def __init__(self, match: re.Match):
         super().__init__(match)
         self.auth_token = self.config("token")
@@ -88,6 +93,9 @@ class SzurubooruExtractor(GalleryExtractor):
                                 f" {api_result['title']} ({api_result['description']})")
 
         for result in api_result['results']:
+            if not result['contentUrl'].startswith('http'):
+                # Relative path
+                result['contentUrl'] = f"{self.base_url}/{result['contentUrl']}"
             result['extension'] = result['contentUrl'].split('.')[-1]
             result['tags_str'] = ','.join([tag['names'][0] for tag in result['tags']])[:250]
 


### PR DESCRIPTION
[Szurubooru](https://github.com/rr-/szurubooru) doesn't have a single domain name because it's open source software you can run yourself. Multiple websites run this booru software.

Szurubooru support was already requested in #3583 but the site referenced there is currently offline. https://booru.foalcon.com/ (NSFW, clop website) runs the same code and that does appear to be online.