### PR TITLE
[deviantart] add support for fxdeviantart.com URLs

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -21,8 +21,8 @@ import re
 
 BASE_PATTERN = (
     r"(?:https?://)?(?:"
-    r"(?:www\.)?deviantart\.com/(?!watch/)([\w-]+)|"
-    r"(?!www\.)([\w-]+)\.deviantart\.com)"
+    r"(?:www\.)?(?:fx)?deviantart\.com/(?!watch/)([\w-]+)|"
+    r"(?!www\.)([\w-]+)\.(?:fx)?deviantart\.com)"
 )
 
 
@@ -997,7 +997,7 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
     subcategory = "deviation"
     archive_fmt = "g_{_username}_{index}.{extension}"
     pattern = (BASE_PATTERN + r"/(art|journal)/(?:[^/?#]+-)?(\d+)"
-               r"|(?:https?://)?(?:www\.)?deviantart\.com/"
+               r"|(?:https?://)?(?:www\.)?(?:fx)?deviantart\.com/"
                r"(?:view/|deviation/|view(?:-full)?\.php/*\?(?:[^#]+&)?id=)"
                r"(\d+)"  # bare deviation ID without slug
                r"|(?:https?://)?fav\.me/d([0-9a-z]+)")  # base36
@@ -1091,6 +1091,9 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
         # old /view/ URLs from the Wayback Machine
         ("https://www.deviantart.com/view.php?id=14864502"),
         ("http://www.deviantart.com/view-full.php?id=100842"),
+
+        ("https://www.fxdeviantart.com/zzz/art/zzz-1234567890"),
+        ("https://www.fxdeviantart.com/view/1234567890"),
     )
 
     skip = Extractor.skip


### PR DESCRIPTION
`fxdeviantart.com` ([source code](https://github.com/robinuniverse/fxdeviantart)) is a service that fixes embeds on Discord, similar to `fxtwitter.com`. It'd be nice to be able to feed URLs directly to gallery-dl without having to strip the prefix manually.

It currently does not support the following URLs:
```
https://foo.fxdeviantart.com/art/1234567890
https://www.fxdeviantart.com/view/1234567890
https://www.fxdeviantart.com/deviation/1234567890
```
dA's oEmbed API does accept such URLs, so this is most likely a bug.