### PR TITLE
[downloader:http] add 'consume-content' option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3617,7 +3617,7 @@ Description
 
 
 downloader.http.consume-content
----------------------------------
+-------------------------------
 Type
     ``bool``
 Default

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3616,6 +3616,25 @@ Description
     contains JPEG/JFIF data.
 
 
+downloader.http.consume-content
+---------------------------------
+Type
+    ``bool``
+Default
+    ``false``
+Description
+    Controls the behavior when an HTTP response is considered
+    unsuccessful
+
+    If the value is ``true``, consume the response body. This
+    avoids closing the connection and therefore improves connection
+    reuse.
+
+    If the value is ``false``, immediately close the connection
+    without reading the response. This can be useful if the server
+    is known to send large bodies for error responses.
+
+
 downloader.http.chunk-size
 --------------------------
 Type

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -306,8 +306,8 @@ class HttpDownloader(DownloaderBase):
         except (RequestException, SSLError, OpenSSLError) as exc:
             print()
             self.log.debug(
-                "Unable to consume response body (%s); "
-                "closing the connection anyway", exc)
+                "Unable to consume response body (%s: %s); "
+                "closing the connection anyway", exc.__class__.__name__, exc)
             response.close()
 
     @staticmethod

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -296,8 +296,15 @@ class HttpDownloader(DownloaderBase):
 
     def release_conn(self, response):
         """Release connection back to pool by consuming response body"""
-        for _ in response.iter_content(self.chunk_size):
-            pass
+        try:
+            for _ in response.iter_content(self.chunk_size):
+                pass
+        except (RequestException, SSLError, OpenSSLError) as exc:
+            print()
+            self.log.debug(
+                "Unable to consume response body (%s); "
+                "closing the connection anyway", exc)
+            response.close()
 
     @staticmethod
     def receive(fp, content, bytes_total, bytes_start):

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -182,7 +182,11 @@ class HttpDownloader(DownloaderBase):
             # check for invalid responses
             validate = kwdict.get("_http_validate")
             if validate and self.validate:
-                result = validate(response)
+                try:
+                    result = validate(response)
+                except Exception:
+                    self.release_conn(response)
+                    raise
                 if isinstance(result, str):
                     url = result
                     tries -= 1

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -175,8 +175,8 @@ class HttpDownloader(DownloaderBase):
                 msg = "'{} {}' for '{}'".format(code, response.reason, url)
                 if code in retry_codes or 500 <= code < 600:
                     continue
-                self.log.warning(msg)
                 self.release_conn(response)
+                self.log.warning(msg)
                 return False
 
             # check for invalid responses
@@ -192,24 +192,24 @@ class HttpDownloader(DownloaderBase):
                     tries -= 1
                     continue
                 if not result:
-                    self.log.warning("Invalid response")
                     self.release_conn(response)
+                    self.log.warning("Invalid response")
                     return False
 
             # check file size
             size = text.parse_int(size, None)
             if size is not None:
                 if self.minsize and size < self.minsize:
+                    self.release_conn(response)
                     self.log.warning(
                         "File size smaller than allowed minimum (%s < %s)",
                         size, self.minsize)
-                    self.release_conn(response)
                     return False
                 if self.maxsize and size > self.maxsize:
+                    self.release_conn(response)
                     self.log.warning(
                         "File size larger than allowed maximum (%s > %s)",
                         size, self.maxsize)
-                    self.release_conn(response)
                     return False
 
             build_path = False


### PR DESCRIPTION
* fix connection not being released when the response is neither successful nor retried

This can be reproduced using the following command:

```
> gallery-dl -v https://example.org/foo.png https://example.org/bar.png

[gallery-dl][debug] Version 1.25.0-dev - Git HEAD: c9a73452
[gallery-dl][debug] Python 3.10.0 - Windows-10-10.0.19044-SP0
[gallery-dl][debug] requests 2.26.0 - urllib3 1.26.7
[gallery-dl][debug] Configuration Files []
[1/2] https://example.org/foo.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/foo.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/foo.png'
[urllib3.connectionpool][debug] Starting new HTTPS connection (1): example.org:443
[urllib3.connectionpool][debug] https://example.org:443 "GET /foo.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/foo.png'
[download][error] Failed to download example.org__foo.png
[2/2] https://example.org/bar.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/bar.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/bar.png'
[urllib3.connectionpool][debug] Starting new HTTPS connection (2): example.org:443
[urllib3.connectionpool][debug] https://example.org:443 "GET /bar.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/bar.png'
[download][error] Failed to download example.org__bar.png
```
According to [`requests`' documentation](https://docs.python-requests.org/en/latest/user/advanced/#body-content-workflow):

> If you set `stream` to `True` when making a request, Requests cannot release the connection back to the pool unless you consume all the data or call `Response.close`. This can lead to inefficiency with connections.

Note that there is no `Resetting dropped connection` in the log, meaning the connection was never released back to the pool.

With this commit:
```
> gallery-dl -v https://example.org/foo.png https://example.org/bar.png

[gallery-dl][debug] Version 1.25.0-dev - Git HEAD: df772714
[gallery-dl][debug] Python 3.10.0 - Windows-10-10.0.19044-SP0
[gallery-dl][debug] requests 2.26.0 - urllib3 1.26.7
[gallery-dl][debug] Configuration Files []
[1/2] https://example.org/foo.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/foo.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/foo.png'
[urllib3.connectionpool][debug] Starting new HTTPS connection (1): example.org:443
[urllib3.connectionpool][debug] https://example.org:443 "GET /foo.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/foo.png'
[download][error] Failed to download example.org__foo.png
[2/2] https://example.org/bar.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/bar.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/bar.png'
[urllib3.connectionpool][debug] Resetting dropped connection: example.org
[urllib3.connectionpool][debug] https://example.org:443 "GET /bar.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/bar.png'
[download][error] Failed to download example.org__bar.png
```

It did create a new HTTPS connection for the second job (confirmed using Wireshark), but this was not shown in the log unless an HTTP proxy was used.

* add the ability to consume the HTTP response body instead of closing the connection

This can improve connection reuse. For example:

```
> gallery-dl -v -o consume-content=true https://example.org/foo.png https://example.org/bar.png

[gallery-dl][debug] Version 1.25.0-dev - Git HEAD: df772714
[gallery-dl][debug] Python 3.10.0 - Windows-10-10.0.19044-SP0
[gallery-dl][debug] requests 2.26.0 - urllib3 1.26.7
[gallery-dl][debug] Configuration Files []
[1/2] https://example.org/foo.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/foo.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/foo.png'
[urllib3.connectionpool][debug] Starting new HTTPS connection (1): example.org:443
[urllib3.connectionpool][debug] https://example.org:443 "GET /foo.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/foo.png'
[download][error] Failed to download example.org__foo.png
[2/2] https://example.org/bar.png
[gallery-dl][debug] Starting DownloadJob for 'https://example.org/bar.png'
[directlink][debug] Using DirectlinkExtractor for 'https://example.org/bar.png'
[urllib3.connectionpool][debug] https://example.org:443 "GET /bar.png HTTP/1.1" 404 648
[downloader.http][warning] '404 Not Found' for 'https://example.org/bar.png'
[download][error] Failed to download example.org__bar.png
```

There will be no change in default behavior except memory efficiency, although `consume-content=true` may perform marginally better than `response.close()` if the response body is small.
