### PR TITLE
[generic] add functools to eval scope

### DIFF
--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -617,6 +617,7 @@ GLOBALS = {
     "hash_sha1": sha1,
     "hash_md5" : md5,
     "re"       : re,
+    "functools": functools,
 }
 
 


### PR DESCRIPTION
I have a pretty complex eval expression to clean the title metadata variable. It applies a list of RegEx subtitutions to the string. Currently, I have to use nested function calls for this, like `re.sub(re.sub(re.sub(re.sub(re.sub(re.sub())))))` which is hard to read and maintain. I would prefer executing this from left to right using `functools.reduce`, making my filename expression in `config.json` look like this:

(as json)

```json
{
  "extractor": {
    "filename": {
      "'num' in locals() and bool(num) and 'title' in locals() and bool(title)": "\fE str(num).zfill(2) + ' – ' + functools.reduce(lambda text, subArguments: re.sub(subArguments[0], subArguments[1], text), [[\"'\", '’'], ['\\.{3}', '…'], ['\\s+', ' '], ['\"(.*?)\"', '“\\g<1>”'], ['[^-\\w,–()[\\]#&:;’„”“… ]+', '_'], ['(^[_\\s]+|[_\\s]+$)', ''], ['^((.{80}).).*$', '\\g<2>…']], title) + '.' + extension",
      "'num' in locals() and bool(num)": "\fE str(num).zfill(2) + '.' + extension",
      "'title' in locals() and bool(title)": "\fE functools.reduce(lambda text, subArguments: re.sub(subArguments[0], subArguments[1], text), [[\"'\", '’'], ['\\.{3}', '…'], ['\\s+', ' '], ['\"(.*?)\"', '“\\g<1>”'], ['[^-\\w,–()[\\]#&:;’„”“… ]+', '_'], ['(^[_\\s]+|[_\\s]+$)', ''], ['^((.{80}).).*$', '\\g<2>…']], title) + '.' + extension",
      "": "{id}.{extension}"
    }
  }
}
```


(as eval expression)

```python
functools.reduce(lambda text, subArguments: re.sub(subArguments[0], subArguments[1], text), [["'", '’'], ['\.{3}', '…'], ['\s+', ' '], ['"(.*?)"', '“\g<1>”'], ['[^-\w,–()[\]#&:;’„”“… ]+', '_'], ['(^[_\s]+|[_\s]+$)', ''], ['^((.{80}).).*$', '\g<2>…']], title)
```

I can run this off my fork, but I still would like to see this merged in case anyone else needs `functools` in their eval expressions.