### PR TITLE
fix: graphql_timeline_v2_bookmark_timeline cannot be null

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -1079,6 +1079,7 @@ class TwitterAPI():
             "responsive_web_graphql_timeline_navigation_enabled": True,
         }
         self.features_pagination = {
+            "graphql_timeline_v2_bookmark_timeline": False,
             "responsive_web_twitter_blue_verified_badge_is_enabled": True,
             "responsive_web_graphql_exclude_directive_enabled": True,
             "verified_phone_label_enabled": False,


### PR DESCRIPTION
twitter: 400 Bad Request (The following features cannot be null: graphql_timeline_v2_bookmark_timeline)