### PR TITLE
[hotleak] Fix downloading of creators whose name starts with a category name

### DIFF
--- a/gallery_dl/extractor/hotleak.py
+++ b/gallery_dl/extractor/hotleak.py
@@ -118,7 +118,7 @@ class HotleakCreatorExtractor(HotleakExtractor):
     """Extractor for all posts from a hotleak creator"""
     subcategory = "creator"
     pattern = (BASE_PATTERN + r"/(?!(?:hot|creators|videos|photos)(?:$|/))"
-              r"([^/?#]+)/?$")
+               r"([^/?#]+)/?$")
     test = (
         ("https://hotleak.vip/kaiyakawaii", {
             "range": "1-200",

--- a/gallery_dl/extractor/hotleak.py
+++ b/gallery_dl/extractor/hotleak.py
@@ -117,7 +117,8 @@ class HotleakPostExtractor(HotleakExtractor):
 class HotleakCreatorExtractor(HotleakExtractor):
     """Extractor for all posts from a hotleak creator"""
     subcategory = "creator"
-    pattern = BASE_PATTERN + r"/(?!(?:hot|creators|videos|photos)(?:$|/))([^/?#]+)/?$"
+    pattern = (BASE_PATTERN + r"/(?!(?:hot|creators|videos|photos)(?:$|/))"
+              r"([^/?#]+)/?$")
     test = (
         ("https://hotleak.vip/kaiyakawaii", {
             "range": "1-200",

--- a/gallery_dl/extractor/hotleak.py
+++ b/gallery_dl/extractor/hotleak.py
@@ -58,7 +58,7 @@ def decode_video_url(url):
 class HotleakPostExtractor(HotleakExtractor):
     """Extractor for individual posts on hotleak"""
     subcategory = "post"
-    pattern = (BASE_PATTERN + r"/(?!hot|creators|videos|photos)"
+    pattern = (BASE_PATTERN + r"/(?!(?:hot|creators|videos|photos)(?:$|/))"
                r"([^/]+)/(photo|video)/(\d+)")
     test = (
         ("https://hotleak.vip/kaiyakawaii/photo/1617145", {
@@ -117,7 +117,7 @@ class HotleakPostExtractor(HotleakExtractor):
 class HotleakCreatorExtractor(HotleakExtractor):
     """Extractor for all posts from a hotleak creator"""
     subcategory = "creator"
-    pattern = BASE_PATTERN + r"/(?!hot|creators|videos|photos)([^/?#]+)/?$"
+    pattern = BASE_PATTERN + r"/(?!(?:hot|creators|videos|photos)(?:$|/))([^/?#]+)/?$"
     test = (
         ("https://hotleak.vip/kaiyakawaii", {
             "range": "1-200",


### PR DESCRIPTION
E.g. `hot4lexi` would start downloading the `hot` section by mistake

This happened because the regex had a negative lookahead for the category names, but didn't ensure that they where followed by either end-of-string or a slash.