### PR TITLE
added Macports install instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,15 @@ For macOS or Linux users using Homebrew:
 
     brew install gallery-dl
 
+MacPorts
+--------
+
+For macOS users with MacPorts:
+
+.. code:: bash
+
+    sudo port install gallery-dl
+
 
 Usage
 =====


### PR DESCRIPTION
Just a simple add to the README for Macports install