### PR TITLE
[pixiv] allow sorting by popularity (requires pixiv premium)

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -596,6 +596,9 @@ class PixivSearchExtractor(PixivExtractor):
         sort_map = {
             "date": "date_asc",
             "date_d": "date_desc",
+            "popular_d": "popular_desc",
+            "popular_male_d": "popular_male_desc",
+            "popular_female_d": "popular_female_desc",
         }
         try:
             self.sort = sort = sort_map[sort]


### PR DESCRIPTION
Added the popularity sorting modes to the tag search downloader.
This requires pixiv premium on the account used for downloading (I have premium and verified these parameters work).