### PR TITLE
[reddit] fix extraction for cross-posted reddit videos and galleries

### DIFF
--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -56,17 +56,26 @@ class RedditExtractor(Extractor):
                     submission["num"] = 0
 
                     url = submission["url"]
-                    if url and url.startswith("https://i.redd.it/"):
+                    if not url:
+                        continue
+
+                    if url.startswith("https://i.redd.it/"):
                         text.nameext_from_url(url, submission)
                         yield Message.Url, url, submission
 
-                    elif "gallery_data" in submission:
+                    elif url.startswith("https://www.reddit.com/gallery/"):
+                        submission_with_gallery = submission
+                        if "crosspost_parent_list" in submission_with_gallery:
+                            submission_with_gallery = submission["crosspost_parent_list"][-1]
+                        if "gallery_data" not in submission_with_gallery:
+                            continue
+
                         for submission["num"], url in enumerate(
-                                self._extract_gallery(submission), 1):
+                            self._extract_gallery(submission_with_gallery), 1):
                             text.nameext_from_url(url, submission)
                             yield Message.Url, url, submission
 
-                    elif submission["is_video"]:
+                    elif url.startswith("https://v.redd.it/"):
                         if videos:
                             text.nameext_from_url(url, submission)
                             url = "ytdl:" + self._extract_video(submission)

--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -64,14 +64,16 @@ class RedditExtractor(Extractor):
                         yield Message.Url, url, submission
 
                     elif url.startswith("https://www.reddit.com/gallery/"):
-                        submission_with_gallery = submission
-                        if "crosspost_parent_list" in submission_with_gallery:
-                            submission_with_gallery = submission["crosspost_parent_list"][-1]
-                        if "gallery_data" not in submission_with_gallery:
+                        gallery_submission = submission
+                        if "crosspost_parent_list" in gallery_submission:
+                            gallery_submission = \
+                                submission["crosspost_parent_list"][-1]
+                        if "gallery_data" not in gallery_submission:
                             continue
 
-                        for submission["num"], url in enumerate(
-                            self._extract_gallery(submission_with_gallery), 1):
+                        gallery = self._extract_gallery(gallery_submission)
+
+                        for submission["num"], url in enumerate(gallery, 1):
                             text.nameext_from_url(url, submission)
                             yield Message.Url, url, submission
 


### PR DESCRIPTION
The previous if statements determining the type of a submission would ignore video and gallery submissions if the post was cross posted, resulting in the submission url getting ignored and marked as unsupported.
Changed the if checks to be similar to the if check for image posts. Also had to get the gallery data of a post from its parent post (which is already present in the submission in the `crosspost_parent_list` attribute) since it doesn't exist in the base submission object.

Video cross-post example: https://www.reddit.com/r/kittengifs/comments/12m0b8d/the_cutest_handful/
Gallery cross-post example (took some time to find): https://www.reddit.com/r/MinecraftBedrockers/comments/130vufu/for_some_reason_i_permanently_have_a_cursed_water/

Closes https://github.com/mikf/gallery-dl/issues/887
Closes https://github.com/mikf/gallery-dl/issues/3586