### PR TITLE
[danbooru] add support for booru.borvar.art instance

### DIFF
--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -161,6 +161,10 @@ BASE_PATTERN = DanbooruExtractor.update({
         "root": None,
         "pattern": r"(?:safe.)?aibooru\.online",
     },
+    "booruvar": {
+        "root": "https://booru.borvar.art",
+        "pattern": r"booru\.borvar\.art"
+    },
 })
 
 


### PR DESCRIPTION
add support for another danbooru instance.
right now as I open this PR i realized it's possible to add custom danbooru instances from the config, just have to use "Danbooru" category instead of "danbooru" which i was trying.
Since I already made a commit for this, I'll leave it up to you if you want to add another site to the defaults or not. Feel free to close this PR if not.
