### PR TITLE
add jpg.pet as alias for jpgfish

### DIFF
--- a/gallery_dl/extractor/jpgfish.py
+++ b/gallery_dl/extractor/jpgfish.py
@@ -9,7 +9,7 @@
 from .common import Extractor, Message
 from .. import text
 
-BASE_PATTERN = r"(?:https?://)?jpg\.(?:fishing|church)"
+BASE_PATTERN = r"(?:https?://)?jpg\.(?:fishing|church|pet)"
 
 
 class JpgfishExtractor(Extractor):


### PR DESCRIPTION
The domain jpg.pet is just an alias for the existing jpgfish module.