### PR TITLE
[Newgrounds] Extract & pass auth token

### DIFF
--- a/gallery_dl/extractor/newgrounds.py
+++ b/gallery_dl/extractor/newgrounds.py
@@ -90,11 +90,13 @@ class NewgroundsExtractor(Extractor):
         headers = {"Origin": self.root, "Referer": url}
         url = text.urljoin(self.root, text.extr(
             response.text, 'action="', '"'))
+        auth_token = text.extr(response.text, 'name="auth" value="', '"')
         data = {
             "username": username,
             "password": password,
             "remember": "1",
             "login"   : "1",
+            "auth"    : auth_token
         }
 
         response = self.request(url, method="POST", headers=headers, data=data)


### PR DESCRIPTION
On my system, I was getting `[newgrounds][error] AuthenticationError: Invalid or missing login credentials` when gallery-dl tried to login to Newgrounds. Running with `-o write-pages=all` showed I was getting an error from Newgrounds `Missing / invalid required token.`

Looking at a normal login request, there's a hidden auth token on /passport/ that is also passed along with credentials. After adding these lines to extract & pass that along, I was able to successfully login & download from Newgrounds.