### PR TITLE
[bunkr] fix media domain for cdn9

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -10,6 +10,12 @@
 
 from .lolisafe import LolisafeAlbumExtractor
 from .. import text
+from urllib.parse import urlsplit, urlunsplit
+
+MEDIA_DOMAIN_OVERRIDES = {
+    "cdn9.bunkr.ru" : "c9.bunkr.ru",
+    "cdn12.bunkr.ru": "media-files12.bunkr.la",
+}
 
 
 class BunkrAlbumExtractor(LolisafeAlbumExtractor):
@@ -92,11 +98,12 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             url = text.unescape(url)
             if url.endswith((".mp4", ".m4v", ".mov", ".webm", ".mkv", ".ts",
                              ".zip", ".rar", ".7z")):
-                if url.startswith("https://cdn12."):
-                    url = ("https://media-files12.bunkr.la" +
-                           url[url.find("/", 14):])
+                scheme, domain, path, query, fragment = urlsplit(url)
+                if domain in MEDIA_DOMAIN_OVERRIDES:
+                    domain = MEDIA_DOMAIN_OVERRIDES[domain]
                 else:
-                    url = url.replace("://cdn", "://media-files", 1)
+                    domain = domain.replace("cdn", "media-files", 1)
+                url = urlunsplit((scheme, domain, path, query, fragment))
             append({"file": url, "_http_headers": headers})
 
         return files, {


### PR DESCRIPTION
Somewhat recently, Bunkr migrated the content of the cdn9 media server to a new host. With the migration, they gave it a new domain; the old domain now just returns 502. This PR adds a mapping for that domain, similar to the special case for cdn12.

Only manually tested so far, using the public album list to find an album. I don't have a bunkr account to upload suitable (small, SFW) test files - if you do, feel free to edit the PR to add a test case.

Fixes #4386