### PR TITLE
[bunkr] Fix extracting wmv files

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -11,6 +11,11 @@
 from .lolisafe import LolisafeAlbumExtractor
 from .. import text
 
+CDN_HOSTED_EXTENSIONS = (
+    ".mp4", ".m4v", ".mov", ".webm", ".mkv", ".ts", ".wmv",
+    ".zip", ".rar", ".7z",
+)
+
 
 class BunkrAlbumExtractor(LolisafeAlbumExtractor):
     """Extractor for bunkrr.su albums"""
@@ -90,8 +95,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
                 url = cdn + url[2:]
 
             url = text.unescape(url)
-            if url.endswith((".mp4", ".m4v", ".mov", ".webm", ".mkv", ".ts",
-                             ".zip", ".rar", ".7z")):
+            if url.lower().endswith(CDN_HOSTED_EXTENSIONS):
                 if url.startswith("https://cdn12."):
                     url = ("https://media-files12.bunkr.la" +
                            url[url.find("/", 14):])


### PR DESCRIPTION
The Bunkr extractor already had support for a number of file extensions that Bunkr hosts on a separate CDN. This PR adds another one, `.wmv`. I also found a few cases of files like `foo.MOV` which weren't being handled correctly, so this PR also updates the check to be case-insensitive.