### PR TITLE
[bunkr] fixed extractor

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -95,7 +95,8 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             if url.startswith("/"):
                 if not cdn:
                     # fetch cdn root from download page
-                    durl = text.unescape("{}/{}/{}".format(self.root, url[1], url[3:]))
+                    durl = text.unescape("{}/{}/{}".format(
+                         self.root, url[1], url[3:]))
                     if url[1] == 'v':
                         cdn = text.extr(self.request(
                             durl).text, '<source src="', '"')

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -95,9 +95,9 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             if url.startswith("/"):
                 if not cdn:
                     # fetch cdn root from download page
-                    durl = "{}/d/{}".format(self.root, url[3:])
+                    vurl = "{}/v/{}".format(self.root, url[3:])
                     cdn = text.extr(self.request(
-                        durl).text, 'link.href = "', '"')
+                        vurl).text, '<source src="', '"')
                     cdn = cdn[:cdn.index("/", 8)]
                 url = cdn + url[2:]
 

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -11,6 +11,7 @@
 from .lolisafe import LolisafeAlbumExtractor
 from .. import text
 from urllib.parse import urlsplit, urlunsplit
+import html
 
 MEDIA_DOMAIN_OVERRIDES = {
     "cdn9.bunkr.ru" : "c9.bunkr.ru",
@@ -95,12 +96,13 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             if url.startswith("/"):
                 if not cdn:
                     # fetch cdn root from download page
-                    vurl = "{}/v/{}".format(self.root, url[3:])
-                    cdn = text.extr(self.request(
-                        vurl).text, '<source src="', '"')
+                    durl = text.unescape("{}/{}/{}".format(self.root, url[1], url[3:]))
+                    if url[1] == 'v':
+                        cdn = text.extr(self.request(durl).text, '<source src="', '"')
+                    else:
+                        cdn = text.extr(self.request(durl).text, '<img src="', '"')
                     cdn = cdn[:cdn.index("/", 8)]
                 url = cdn + url[2:]
-
             url = text.unescape(url)
             if url.lower().endswith(CDN_HOSTED_EXTENSIONS):
                 scheme, domain, path, query, fragment = urlsplit(url)

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -93,18 +93,16 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
         pos = page.index('class="grid-images')
         for url in text.extract_iter(page, '<a href="', '"', pos):
             if url.startswith("/"):
-                if not cdn:
-                    # fetch cdn root from download page
-                    durl = text.unescape("{}/{}/{}".format(
-                        self.root, url[1], url[3:]))
-                    if url[1] == 'v':
-                        cdn = text.extr(self.request(
-                            durl).text, '<source src="', '"')
-                    else:
-                        cdn = text.extr(self.request(
-                            durl).text, '<img src="', '"')
-                    cdn = cdn[:cdn.index("/", 8)]
-                url = cdn + url[2:]
+                # fetch cdn root from download page
+                durl = text.unescape("{}/{}/{}".format(
+                    self.root, url[1], url[3:]))
+                if url[1] == 'v':
+                    cdn = text.extr(self.request(
+                        durl).text, '<source src="', '"')
+                else:
+                    cdn = text.extr(self.request(
+                        durl).text, '<img src="', '"')
+                url = cdn
 
             url = text.unescape(url)
             if url.lower().endswith(CDN_HOSTED_EXTENSIONS):

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -11,7 +11,6 @@
 from .lolisafe import LolisafeAlbumExtractor
 from .. import text
 from urllib.parse import urlsplit, urlunsplit
-import html
 
 MEDIA_DOMAIN_OVERRIDES = {
     "cdn9.bunkr.ru" : "c9.bunkr.ru",
@@ -98,11 +97,14 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
                     # fetch cdn root from download page
                     durl = text.unescape("{}/{}/{}".format(self.root, url[1], url[3:]))
                     if url[1] == 'v':
-                        cdn = text.extr(self.request(durl).text, '<source src="', '"')
+                        cdn = text.extr(self.request(
+                            durl).text, '<source src="', '"')
                     else:
-                        cdn = text.extr(self.request(durl).text, '<img src="', '"')
+                        cdn = text.extr(self.request(
+                            durl).text, '<img src="', '"')
                     cdn = cdn[:cdn.index("/", 8)]
                 url = cdn + url[2:]
+
             url = text.unescape(url)
             if url.lower().endswith(CDN_HOSTED_EXTENSIONS):
                 scheme, domain, path, query, fragment = urlsplit(url)

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -96,7 +96,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
                 if not cdn:
                     # fetch cdn root from download page
                     durl = text.unescape("{}/{}/{}".format(
-                         self.root, url[1], url[3:]))
+                        self.root, url[1], url[3:]))
                     if url[1] == 'v':
                         cdn = text.extr(self.request(
                             durl).text, '<source src="', '"')


### PR DESCRIPTION
https://github.com/mikf/gallery-dl/issues/4514

- The cdn link can now be either `/v/` or `/i/` depending on whether it's a video or image
- Location of link has been adjusted
- Image URL now needs to be unescaped