### PR TITLE
Fix Bunkr extractor

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -81,7 +81,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             if cdn is None:
                 url = self._get_download_url(media_url)
                 cdn = text.root_from_url(url)
-                self.log.debug(f"Using CDN URL: {cdn}")
+                self.log.debug("Using CDN URL: {}".format(cdn))
 
             # We can assemble the correct download URL for media files using:
             #   1. The CDN hostname (e.g. "https://nugget.bunkr.ru")

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -106,7 +106,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
                 # thumbnail because the file has no preview.
                 #   e.g. "/d/Resources-iwizfcKl.url"
                 download_path = text.filename_from_url(media_path)
-                url = f"{cdn}/{download_path}"
+                url = "{}/{}".format(cdn, download_path)
 
             elif media_path.startswith("/i/") or media_path.startswith("/v/"):
                 # For media preview pages, derive the download URL.
@@ -114,7 +114,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
                     thumb_name = text.filename_from_url(thumbnail_url)
                     thumb_base, _, thumb_ext = thumb_name.rpartition(".")
                     orig_base, _, orig_ext = original_name.rpartition(".")
-                    url = f"{cdn}/{thumb_base}.{orig_ext}"
+                    url = "{}/{}.{}".format(cdn, thumb_base, orig_ext)
 
             # If we still don't have a download URL, use the slow method.
             # This is always required for MP3 files as they use a `/v/` media

--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -90,7 +90,7 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
             # The thumbnail file name has the sanitized file name and file ID
             # but we need the file extension from the original file name.
             thumbnail_url = text.extr(html, 'src="', '"')
-            if "no-image.svg" not in thumbnail_url:
+            if "no-image.svg" in thumbnail_url:
                 thumbnail_url = None
 
             details = re.findall(r"<p[^>]+> (.*?) </p>", html, re.VERBOSE)


### PR DESCRIPTION
Fixing the extractor since the recent site redesign. Download URLs can be obtained using additional HTTP requests (slow) or constructing them from other information on the page (fast).

Fixes #4514