### PR TITLE
[Fantia] Keyword rewrite

### DIFF
--- a/gallery_dl/extractor/fantia.py
+++ b/gallery_dl/extractor/fantia.py
@@ -14,9 +14,9 @@ class FantiaExtractor(Extractor):
     """Base class for Fantia extractors"""
     category = "fantia"
     root = "https://fantia.jp"
-    directory_fmt = ("{category}", "{fanclub_id}")
-    filename_fmt = "{post_id}_{file_id}.{extension}"
-    archive_fmt = "{post_id}_{file_id}"
+    directory_fmt = ("{category}", "{fanclub['id']}")
+    filename_fmt = "{id}_{file_id}.{extension}"
+    archive_fmt = "{id}_{file_id}"
     _warning = True
 
     def _init(self):


### PR DESCRIPTION
I wanted to rewrite a part of the extractor to include some useful keywords that weren't exposed before and also redo how they're named as to be more consistent with other extractors.

I don't know if the method is sound, but I build a template dictionary with keys that I want to have in keywords, then with `_build_new_dict`, it goes through the specified keys/subkeys from `_template_post` recursively and returns a newly-built dictionary. I did it this way as it seems for Fantia specifically, there's a lot of garbage in the response that the previous implementation got around by manually specifying what they wanted. While I could've also implemented the keywords like before manually, I thought this might be a little more flexible.

Apologies in advanced as I'm a very novice coder! Let me know if it looks okay.