### PR TITLE
Add support for naver blog videos & fix recent posts bug

### DIFF
--- a/gallery_dl/extractor/naver.py
+++ b/gallery_dl/extractor/naver.py
@@ -11,8 +11,6 @@
 from .common import GalleryExtractor, Extractor, Message
 from .. import text
 from datetime import date
-import json
-import urllib.request
 
 class NaverBase():
     """Base class for naver extractors"""
@@ -86,14 +84,13 @@ class NaverPostExtractor(NaverBase, GalleryExtractor):
             # create list of json urls
             jsons = [f'https://apis.naver.com/rmcnmv/rmcnmv/vod/play/v2.0/{j}?key={k}' for j,k in zip(json_ids, keys)]
             for j in jsons:
-                with urllib.request.urlopen(j) as url:
-                    data = json.loads(url.read().decode())
+                data = self.request(j).json()
 
-                    # Parse source video urls and select highest quality source
-                    sources = data['videos']['list']
-                    sizes = [s['size'] for s in sources]
-                    i = sizes.index(max(sizes))
-                    videos.append((sources[i]['source'], None))
+                # Parse source video urls and select highest quality source
+                sources = data['videos']['list']
+                sizes = [s['size'] for s in sources]
+                i = sizes.index(max(sizes))
+                videos.append((sources[i]['source'], None))
 
         images = [
             (url.replace("://post", "://blog", 1).partition("?")[0], None)

--- a/gallery_dl/extractor/naver.py
+++ b/gallery_dl/extractor/naver.py
@@ -10,7 +10,7 @@
 
 from .common import GalleryExtractor, Extractor, Message
 from .. import text
-
+from datetime import date
 
 class NaverBase():
     """Base class for naver extractors"""
@@ -59,6 +59,11 @@ class NaverPostExtractor(NaverBase, GalleryExtractor):
         data["post"]["date"] = text.parse_datetime(
             extr('se_publishDate pcol2">', '<') or
             extr('_postAddDate">', '<'), "%Y. %m. %d. %H:%M")
+
+        # fixes directory error for posts created less than 24 hours ago
+        if "전" in str(data["post"]["date"]):
+            data["post"]["date"] = text.parse_datetime(date.today().isoformat(), format="%Y-%m-%d")
+
         return data
 
     def images(self, page):


### PR DESCRIPTION
- Add support for Naver blog videos
    - Downloads all images first followed by all videos
    - Example link: https://blog.naver.com/jws790103/223239681955
- Fix recent posts bug
    - When trying to download a post from the past 24 hours the following error occurs:
        - `[naver][error] DirectoryFormatError: Applying directory format string failed (ValueError: Invalid format specifier)`
    - This is fixed by detecting when this is the case and creating a datetime object based on today's date