### PR TITLE
[reddit] implement Reddit Mobile share links

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -712,7 +712,7 @@ Consider all sites to be NSFW unless otherwise known.
 <tr>
     <td>Reddit</td>
     <td>https://www.reddit.com/</td>
-    <td>Home Feed, individual Images, Submissions, Subreddits, User Profiles</td>
+    <td>Home Feed, individual Images, Redirects, Submissions, Subreddits, User Profiles</td>
     <td><a href="https://github.com/mikf/gallery-dl#oauth">OAuth</a></td>
 </tr>
 <tr>

--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -292,6 +292,29 @@ class RedditImageExtractor(Extractor):
         yield Message.Url, url, data
 
 
+class RedditRedirectExtractor(Extractor):
+    """Extractor for personalized share URLs produced by the mobile app"""
+    category = "reddit"
+    subcategory = "redirect"
+    pattern = (r"(?:https?://)?(?:"
+               r"(?:\w+\.)?reddit\.com/(?:(?:r)/([^/?#]+)))"
+               r"/s/([a-zA-Z0-9]{10})")
+    example = "https://www.reddit.com/r/SUBREDDIT/s/abc456GHIJ"
+
+    def __init__(self, match):
+        Extractor.__init__(self, match)
+        self.subreddit = match.group(1)
+        self.share_url = match.group(2)
+
+    def items(self):
+        url = "https://www.reddit.com/r/" + self.subreddit + "/s/" + \
+              self.share_url
+        data = {"_extractor": RedditSubmissionExtractor}
+        response = self.request(url, method="HEAD", allow_redirects=False,
+                                notfound="submission")
+        yield Message.Queue, response.headers["Location"], data
+
+
 class RedditAPI():
     """Interface for the Reddit API
 

--- a/test/results/reddit.py
+++ b/test/results/reddit.py
@@ -240,4 +240,12 @@ __tests__ = (
     "#pattern" : r"^https://i\.redd\.it/00af44lpn0u51\.jpg$",
 },
 
+{
+    "#url"     : "https://www.reddit.com/r/analog/s/hKrTTvFVwZ",
+    "#comment" : "Mobile share URL",
+    "#category": ("", "reddit", "redirect"),
+    "#class"   : reddit.RedditRedirectExtractor,
+    "#pattern" : r"^https://www\.reddit\.com/r/analog/comments/179exao/photographing_the_recent_annular_eclipse_with_a",
+},
+
 )


### PR DESCRIPTION
Reddit Mobile app has implemented a new share URL format relatively recently (somewhere around August), which looks like this:

    https://www.reddit.com/r/analog/s/hKrTTvFVwZ

This is an obfuscated personalized tracking URL which redirects to a submission:

    https://www.reddit.com/r/analog/comments/179exao/photographing_the_recent_annular_eclipse_with_a/?share_id=okPOBW_OzrDClMSiZSLjV&utm_content=1&utm_medium=ios_app&utm_name=ioscss&utm_source=share&utm_term=1

This PR adds a minimal redirect extractor for this URL format.