### PR TITLE
Bluesky post extractor

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -116,6 +116,12 @@ Consider all sites to be NSFW unless otherwise known.
     <td></td>
 </tr>
 <tr>
+    <td>Bluesky</td>
+    <td>https://bsky.app/</td>
+    <td>Posts</td>
+    <td></td>
+</tr>
+<tr>
     <td>Bunkr</td>
     <td>https://bunkrr.su/</td>
     <td>Albums, Media Files</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -27,6 +27,7 @@ modules = [
     "bbc",
     "behance",
     "blogger",
+    "bluesky",
     "bunkr",
     "catbox",
     "chevereto",

--- a/gallery_dl/extractor/bluesky.py
+++ b/gallery_dl/extractor/bluesky.py
@@ -11,7 +11,6 @@ from .. import text, util
 
 import json
 import dataclasses
-import netrc
 import posixpath
 
 import chitose
@@ -31,10 +30,9 @@ class BlueskyAPI():
         # BSKY_USER = extractor.config("username"),
         # BSKY_PASSWD = extractor.config("password")
 
-        rc = netrc.netrc()
-        (BSKY_USER, _, BSKY_PASSWD) = rc.authenticators(instance)
+        username, password = extractor._get_auth_info()
 
-        self.agent.login(BSKY_USER, BSKY_PASSWD)
+        self.agent.login(username, password)
 
     def bskyGetDid(self, user_id: str) -> str:
         return json.loads(self.agent.get_profile(actor=user_id))['did']
@@ -60,7 +58,7 @@ class BlueskyAPI():
 
 class _BlueskyPostExtractor(Extractor):
     """Extractor for bluesky posts"""
-    category = "bluesky"
+    category = "bsky.social"
     subcategory = "post"
     directory_fmt = ("{category}", "{user_id}")
     filename_fmt = "{post_id} {filename}.{extension}"
@@ -72,9 +70,10 @@ class _BlueskyPostExtractor(Extractor):
     def __init__(self, match):
         Extractor.__init__(self, match)
         self.user_id, self.post_id = match.groups()
-        self.api = BlueskyAPI(self)
-        self.json_obj = self.api.getSkeetJson(PostReference(self.user_id, self.post_id))
 
+        self.api = BlueskyAPI(self)
+
+        self.json_obj = self.api.getSkeetJson(PostReference(self.user_id, self.post_id))
         self.metadata = self.json_obj
         self.metadata.update(match.groupdict())
 

--- a/gallery_dl/extractor/bluesky.py
+++ b/gallery_dl/extractor/bluesky.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://bsky.social/"""
+
+from .common import Extractor, Message
+from .. import text, util
+
+import json
+import dataclasses
+import netrc
+import posixpath
+
+import chitose
+
+@dataclasses.dataclass(unsafe_hash=True)
+class PostReference():
+    user_id: str = dataclasses.field(hash=True)
+    post_id: str = dataclasses.field(hash=True)
+
+class BlueskyAPI():
+    def __init__(self, extractor, instance="bsky.social"):
+        self.root = extractor.root
+        self.extractor = extractor
+
+        self.agent = chitose.BskyAgent(service=f'https://{instance}')
+
+        # BSKY_USER = extractor.config("username"),
+        # BSKY_PASSWD = extractor.config("password")
+
+        rc = netrc.netrc()
+        (BSKY_USER, _, BSKY_PASSWD) = rc.authenticators(instance)
+
+        self.agent.login(BSKY_USER, BSKY_PASSWD)
+
+    def bskyGetDid(self, user_id: str) -> str:
+        return json.loads(self.agent.get_profile(actor=user_id))['did']
+
+    def bskyTupleToUri(self, post_reference: PostReference) -> str:
+        return f"at://{self.bskyGetDid(post_reference.user_id)}/app.bsky.feed.post/{post_reference.post_id}"
+
+    def bskyGetThread(self, post_reference) -> dict:
+        thread_response = self.agent.get_post_thread(
+            uri=self.bskyTupleToUri(post_reference)
+        )
+        thread_response = json.loads(thread_response)
+
+        return thread_response
+
+    def getSkeetJson(self, post_reference):
+        thread_response = self.bskyGetThread(post_reference)
+        thread_response['thread']['post']['id'] = post_reference.post_id
+
+        json_obj = thread_response['thread']['post']
+
+        return json_obj
+
+class _BlueskyPostExtractor(Extractor):
+    """Extractor for bluesky posts"""
+    category = "bluesky"
+    subcategory = "post"
+    directory_fmt = ("{category}", "{user_id}")
+    filename_fmt = "{post_id} {filename}.{extension}"
+    root = "https://bsky.social"
+    referer = False
+    pattern = r"(?:https?://)?bsky.app/profile/(?P<user_id>[^/]+)/post/(?P<post_id>[^ )]+)"
+    example = "https://bsky.app/profile/im.giovanh.com/post/3kaxkwevkn626"
+
+    def __init__(self, match):
+        Extractor.__init__(self, match)
+        self.user_id, self.post_id = match.groups()
+        self.api = BlueskyAPI(self)
+        self.json_obj = self.api.getSkeetJson(PostReference(self.user_id, self.post_id))
+
+        self.metadata = self.json_obj
+        self.metadata.update(match.groupdict())
+
+    def items(self):
+
+        yield Message.Directory, self.metadata
+
+        for image_def in self.json_obj.get('embed', {}).get('images', []):
+            src_url = image_def['fullsize']
+            name = posixpath.split(src_url)[-1].replace('@', '.')
+            img_meta = text.nameext_from_url(name, None)
+            img_meta.update(self.metadata)
+            yield Message.Url, src_url, img_meta


### PR DESCRIPTION
Functional bluesky downloader.

Example:

```text
py -3.11 -m gallery_dl --verbose "https://bsky.app/profile/im.giovanh.com/post/3kaxkwevkn626" --verbose
[gallery-dl][debug] Version 1.26.2-dev - Git HEAD: b029f25f
[gallery-dl][debug] Python 3.11.5 - Windows-10-10.0.19045-SP0
[gallery-dl][debug] requests 2.31.0 - urllib3 1.26.16
[gallery-dl][debug] Configuration Files []
[gallery-dl][debug] Starting DownloadJob for 'https://bsky.app/profile/im.giovanh.com/post/3kaxkwevkn626'
[bluesky][debug] Using _BlueskyPostExtractor for 'https://bsky.app/profile/im.giovanh.com/post/3kaxkwevkn626'
[urllib3.connectionpool][debug] Starting new HTTPS connection (1): cdn.bsky.app:443
[urllib3.connectionpool][debug] https://cdn.bsky.app:443 "GET /img/feed_fullsize/plain/did:plc:kjx6y3groxh3sy5tkfyji6sy/baf
kreif5rwbbx3nrz4v3kcaqjycjohie7lkaempzffqu4ggqehww34jjpe@jpeg HTTP/1.1" 200 203359
* .\gallery-dl\bluesky\im.giovanh.com\3kaxkwevkn626 bafkreif5rwbbx3nrz4v3kcaqjycjohie7lkaempzffqu4ggqehww34jjpe.jpg
```

TODO;
- [x] Replace netrc with gallery-dl native authentication
- [ ] Remove chitose dependency (???? @mikf)
- [ ] Metadata postprocessor should store metadata by-post by default. Instead, it's targeting a global `metadata.json` file. @mikf this looks like there's pathfmt data missing based on what I see in MetadataPP; what's the best way to set a default for this?
- [x] Add readme