### PR TITLE
[urlgalleries] add support

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -890,6 +890,12 @@ Consider all sites to be NSFW unless otherwise known.
     <td></td>
 </tr>
 <tr>
+    <td>Urlgalleries</td>
+    <td>https://urlgalleries.net/</td>
+    <td>Galleries</td>
+    <td></td>
+</tr>
+<tr>
     <td>Vipergirls</td>
     <td>https://vipergirls.to/</td>
     <td>Posts, Threads</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -155,6 +155,7 @@ modules = [
     "tumblrgallery",
     "twibooru",
     "twitter",
+    "urlgalleries",
     "unsplash",
     "uploadir",
     "urlshortener",

--- a/gallery_dl/extractor/urlgalleries.py
+++ b/gallery_dl/extractor/urlgalleries.py
@@ -10,7 +10,7 @@ from .common import GalleryExtractor
 from .. import text
 
 
-class UrlgalleriesExtractor(GalleryExtractor):
+class UrlgalleriesGalleryExtractor(GalleryExtractor):
     """Base class for Urlgalleries extractors"""
     category = "urlgalleries"
     root = "urlgalleries.net"

--- a/gallery_dl/extractor/urlgalleries.py
+++ b/gallery_dl/extractor/urlgalleries.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://urlgalleries.net/"""
+
+from .common import GalleryExtractor
+from .. import text
+
+
+class UrlgalleriesExtractor(GalleryExtractor):
+    """Base class for Urlgalleries extractors"""
+    category = "urlgalleries"
+    root = "urlgalleries.net"
+    directory_fmt = ("{category}", "{title}")
+    pattern = r"(?:https?://)([^/?#]+)?\.urlgalleries\.net/([^/?#]+)/([^/?#]+)"
+    example = "https://blog.urlgalleries.net/gallery-1234567/a-title--1234"
+
+    def __init__(self, match):
+        self.blog = match.group(1)
+        self.gallery_id = match.group(2)
+        self.title = match.group(3)
+        url = "{}.urlgalleries.net/{}/{}&a=10000".format(
+            self.blog, self.gallery_id, self.title)
+        GalleryExtractor.__init__(self, match, text.ensure_http_scheme(url))
+
+    def images(self, page):
+        extr = text.extr(page, 'id="wtf"', "</div>")
+        url = "{}{{}}".format(self.root).format
+        return [
+            (text.ensure_http_scheme(url(i)), None)
+            for i in text.extract_iter(extr, "href='", "'")
+        ]
+
+    def metadata(self, page):
+        date = text.extr(
+            page, "float:left;'>  ", '</div>').split(" | ")[-1]
+        return {
+            'title': self.title,
+            'date': text.parse_datetime(date, format='%B %d, %Y T%H:%M')
+        }


### PR DESCRIPTION
For #919, #1184, #2905

### incomplete

Gallery image urls redirect to a hosting site:

gallery url - `https://beautiesonearth.urlgalleries.net/porn-gallery-6915206/gemma-arterton-%2a100-streets%2a-premiere-in-london-nov-8`

image url - `https://beautiesonearth.urlgalleries.net/gemma-arterton-+100-streets+-premiere-in-london-nov-8-w59n0dk3qy.jpg`

image url forwards to - `https://pixhost.to/show/952/35141831_dcotqomb.jpg`

The extractor needs corrected to follow the redirect, work in progress. Right now it saves the image host source code as an image file.