### PR TITLE
Fix for "[patreon][error] Unable to extract bootstrap data #4904"

### DIFF
--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -250,16 +250,19 @@ class PatreonExtractor(Extractor):
 
     def _extract_bootstrap(self, page):
         if "window.patreon.bootstrap," in page:
-            page_content = text.extr(page, "window.patreon.bootstrap,", "});")
-            json_string = page_content + "}"
+            content_begin = "window.patreon.bootstrap,"
+            content_end = "});"
+            json_string = text.extr(page, content_begin, content_end) + "}"
         elif 'window.patreon = {"bootstrap":' in page:
-            page_content = text.extr(page, 'window.patreon = {"bootstrap":', '},"apiServer"')
-            json_string = page_content + "}"
+            content_begin = 'window.patreon = {"bootstrap":'
+            content_end = '},"apiServer"'
+            json_string = text.extr(page, content_begin, content_end) + "}"
         elif 'window.patreon = wrapInProxy({"bootstrap":' in page:
-            page_content = text.extr(page, 'window.patreon = wrapInProxy({"bootstrap":', '},"apiServer"')
-            json_string = page_content + "}"
+            content_begin = 'window.patreon = wrapInProxy({"bootstrap":'
+            content_end = '},"apiServer"'
+            json_string = text.extr(page, content_begin, content_end) + "}"
         else:
-            raise Exception(f"Unknown HTML and JS structure. Page content is: {page}")
+            raise Exception("Unknown HTML and JS structure. Page:" + page)
         return util.json_loads(json_string)
 
 

--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -255,7 +255,9 @@ class PatreonExtractor(Extractor):
             return util.json_loads(bootstrap + "}")
 
         bootstrap = text.extr(
-            page, 'window.patreon = wrapInProxy({"bootstrap":', '},"apiServer"')
+            page,
+            'window.patreon = wrapInProxy({"bootstrap":',
+            '},"apiServer"')
         if bootstrap:
             return util.json_loads(bootstrap + "}")
 


### PR DESCRIPTION
TLDR: `window.patreon = {"bootstrap":'` did not work anymore. Change it to `window.patreon = wrapInProxy({"bootstrap":`

Feel free to change, approve or deny it.