### PR TITLE
[zzup] add 'gallery' extractor

### DIFF
--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -178,6 +178,7 @@ modules = [
     "xhamster",
     "xvideos",
     "zerochan",
+    "zzup",
     "booru",
     "moebooru",
     "foolfuuka",

--- a/gallery_dl/extractor/zzup.py
+++ b/gallery_dl/extractor/zzup.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from .common import GalleryExtractor
+from .. import text
+
+
+class ZzupGalleryExtractor(GalleryExtractor):
+    category = "zzup"
+    directory_fmt = ("{category}", "{title}")
+    filename_fmt = "{slug}_{num:>03}.{extension}"
+    archive_fmt = "{slug}_{num}"
+    root = "https://zzup.com"
+    pattern = (r"(?:https?://)?(?:www\.)?zzup\.com(/content"
+               r"/[\w=]+/([^/?#]+)/[\w=]+)/(?:index|page-\d+)\.html")
+    example = "https://zzup.com/content/xyz=/12345_TITLE/123=/index.html"
+
+    def __init__(self, match):
+        url = "{}/{}/index.html".format(self.root, match.group(1))
+        GalleryExtractor.__init__(self, match, url)
+        self.slug = match.group(2)
+
+    def metadata(self, page):
+        return {
+            "slug" : self.slug,
+            "title": text.unescape(text.extr(
+                page, "<title>", "</title>"))[:-11],
+        }
+
+    def images(self, page):
+        path = text.extr(page, 'class="picbox"><a target="_blank" href="', '"')
+        count = text.parse_int(text.extr(path, "-pics-", "-mirror"))
+        page = self.request(self.root + path).text
+        url = self.root + text.extr(page, '\n<a href="', '"')
+        p1, _, p2 = url.partition("/image0")
+        ufmt = p1 + "/image{:>05}" + p2[4:]
+        return [(ufmt.format(num), None) for num in range(1, count + 1)]

--- a/test/results/zzup.py
+++ b/test/results/zzup.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from gallery_dl.extractor import zzup
+
+
+__tests__ = (
+{
+    "#url"     : "https://zzup.com/content/NjM=/MetArt_20080206_viki_c_sensazioni_by_ingret/OTE=/index.html",
+    "#category": ("", "zzup", "gallery"),
+    "#class"   : zzup.ZzupGalleryExtractor,
+    "#pattern" : r"https://zzup\.com/MjAxNjc3OTIyMjE5Nzk=/showimage/zzup-8769086487/image00\d\d\d-5896498214-1-9689595623/MetArt-20080206_viki_c_sensazioni_by_ingret/9879560327/zzup.com.jpg",
+
+    "slug"  : "MetArt_20080206_viki_c_sensazioni_by_ingret",
+    "title" : "MetArt 20080206 viki c sensazioni by ingret",
+    "num"   : int,
+    "count" : 135,
+},
+
+{
+    "#url"     : "https://zzup.com/content/MTc2MDYxMw==/Courtesan/NDA=/page-1.html",
+    "#category": ("", "zzup", "gallery"),
+    "#class"   : zzup.ZzupGalleryExtractor,
+    "#pattern" : r"https://zzup.com/MjAxNjc3OTIyMjE5Nzk=/showimage/zzup-8769086487/image000\d\d-5896498214-40-9689595623/Courtesan/9879560327/zzup.com.jpg",
+},
+
+)
+


### PR DESCRIPTION
closes #4517, #4659, #4863

`ZzupImageExtractor` is possible but would require 1 additional request, or by `.replace("_", " ")` the slug.