### PR TITLE
Dockerfile/chore: Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:alpine
-RUN python3 -m pip install -U gallery-dl yt-dlp
-RUN apk update
-RUN apk add ffmpeg
+RUN python3 -m pip install --no-cache-dir -U pip  && \
+    python3 -m pip install --no-cache-dir -U gallery-dl yt-dlp
+RUN apk update && \
+    apk add --no-cache ffmpeg && \
+    rm -rf /var/cache/apk/*
 ENTRYPOINT [ "gallery-dl" ]


### PR DESCRIPTION
Reduce a layer, update pip and apk, and reduce increased image size by optimization.

The previous image size is approximately 247 MB. With this PR, 244 MB

Without the code below
```
python3 -m pip install --no-cache-dir -U pip  && \
```
the image will be 10MB smaller.

