### PR TITLE
[naver] EUC-KR encoding issue in old image URLs

### DIFF
--- a/gallery_dl/extractor/naver.py
+++ b/gallery_dl/extractor/naver.py
@@ -10,6 +10,7 @@
 
 from .common import GalleryExtractor, Extractor, Message
 from .. import text
+from urllib.parse import unquote
 
 
 class NaverBase():
@@ -63,7 +64,13 @@ class NaverPostExtractor(NaverBase, GalleryExtractor):
 
     def images(self, page):
         return [
-            (url.replace("://post", "://blog", 1).partition("?")[0], None)
+            (unquote(url, encoding="EUC-KR")
+             .replace("://post", "://blog", 1)
+             .partition("?")[0], None)
+            if "\ufffd" in unquote(url)
+            else
+            (url.replace("://post", "://blog", 1)
+             .partition("?")[0], None)
             for url in text.extract_iter(page, 'data-lazy-src="', '"')
         ]
 

--- a/gallery_dl/extractor/naver.py
+++ b/gallery_dl/extractor/naver.py
@@ -10,7 +10,6 @@
 
 from .common import GalleryExtractor, Extractor, Message
 from .. import text
-from urllib.parse import unquote
 
 
 class NaverBase():
@@ -63,16 +62,13 @@ class NaverPostExtractor(NaverBase, GalleryExtractor):
         return data
 
     def images(self, page):
-        return [
-            (unquote(url, encoding="EUC-KR")
-             .replace("://post", "://blog", 1)
-             .partition("?")[0], None)
-            if "\ufffd" in unquote(url)
-            else
-            (url.replace("://post", "://blog", 1)
-             .partition("?")[0], None)
-            for url in text.extract_iter(page, 'data-lazy-src="', '"')
-        ]
+        results = []
+        for url in text.extract_iter(page, 'data-lazy-src="', '"'):
+            url = url.replace("://post", "://blog", 1).partition("?")[0]
+            if "\ufffd" in text.unquote(url):
+                url = text.unquote(url, encoding="EUC-KR")
+            results.append((url, None))
+        return results
 
 
 class NaverBlogExtractor(NaverBase, Extractor):

--- a/test/results/naver.py
+++ b/test/results/naver.py
@@ -25,6 +25,33 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://blog.naver.com/PostView.nhn?blogId=rlfqjxm0&logNo=70161391809",
+    "#comment" : "filenames in EUC-KR encoding (#5126)",
+    "#category": ("", "naver", "post"),
+    "#class"   : naver.NaverPostExtractor,
+    "#urls": (
+        "https://blogfiles.pstatic.net/20130305_23/ping9303_1362411028002Dpz9z_PNG/1_사본.png",
+        "https://blogfiles.pstatic.net/20130305_46/rlfqjxm0_1362473322580x33zi_PNG/오마갓합작.png",
+    ),
+
+    "blog": {
+        "id"  : "rlfqjxm0",
+        "num" : 43030507,
+        "user": "에나",
+    },
+    "post": {
+        "date"       : "dt:2013-03-05 17:48:00",
+        "description": "&amp;nbsp;◈ &amp;nbsp; &amp;nbsp; PROMOTER&amp;nbsp;：핑수 ˚ 아담 EDITOR：핑수 &amp;nbsp; 넵：이크：핑수...",
+        "num"        : 70161391809,
+        "title"      : "[공유] {&#8201;합작}&#8201; OH, MY GOD! ~ 아 또 무슨 종말을 한다 그래~"
+    },
+    "count"    : 2,
+    "num"      : range(1, 2),
+    "filename" : r"re:1_사본|오마갓합작",
+    "extension": "png",
+},
+
+{
     "#url"     : "https://blog.naver.com/gukjung",
     "#category": ("", "naver", "blog"),
     "#class"   : naver.NaverBlogExtractor,


### PR DESCRIPTION
Around October 2016, the image server URL format and file name encoding changed from EUC-KR to UTF-8. Modified to detect old URL format and decode image URLs into EUC-KR