### PR TITLE
[toonily] add support

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -854,6 +854,12 @@ Consider all listed sites to potentially be NSFW.
     <td></td>
 </tr>
 <tr>
+    <td>Toonily</td>
+    <td>https://toonily.com/</td>
+    <td>Chapters, Manga</td>
+    <td></td>
+</tr>
+<tr>
     <td>Toyhouse</td>
     <td>https://toyhou.se/</td>
     <td>Art, individual Images</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -154,6 +154,7 @@ modules = [
     "telegraph",
     "tmohentai",
     "toyhouse",
+    "toonily",
     "tsumino",
     "tumblr",
     "tumblrgallery",

--- a/gallery_dl/extractor/toonily.py
+++ b/gallery_dl/extractor/toonily.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://toonily.com/"""
+
+from .common import ChapterExtractor, MangaExtractor
+from .. import text, exception
+import re
+
+
+class ToonilyBase():
+    """Base class for Toonily extractors"""
+    category = "toonily"
+    root = "https://toonily.com"
+
+    @staticmethod
+    def parse_chapter_string(chapter_string, data):
+        match = re.match(
+            r"(?:(.+)\s*-\s*)?[Cc]hapter\s*(\d+)(\.\d+)?(?:\s*-\s*(.+))?",
+            text.unescape(chapter_string).strip())
+        manga, chapter, minor, title = match.groups()
+        manga = manga.strip() if manga else ""
+        data["manga"] = data.pop("manga", manga)
+        data["chapter"] = text.parse_int(chapter)
+        data["chapter_minor"] = minor or ""
+        data["title"] = title or ""
+        data["lang"] = "en"
+        data["language"] = "English"
+
+
+class ToonilyChapterExtractor(ToonilyBase, ChapterExtractor):
+    """Extractor for manga-chapters from toonily.com"""
+    pattern = (r"(?:https?://)?(?:www\.)?toonily\.com"
+               r"(/webtoon/[^/?#]+/[^/?#]+)")
+    example = "https://toonily.com/webtoon/MANGA/chapter-01/"
+
+    def metadata(self, page):
+        tags = text.extr(page, 'class="wp-manga-tags-list">', '</div>')
+        data = {"tags": list(text.split_html(tags)[::2])}
+        info = text.extr(page, '<h1 id="chapter-heading">', "</h1>")
+        if not info:
+            raise exception.NotFoundError("chapter")
+        self.parse_chapter_string(info, data)
+        return data
+
+    def images(self, page):
+        page = text.extr(
+            page, '<div class="reading-content">', '<div class="entry-header')
+        return [
+            (text.extr(img, 'src="', '"').strip(), None)
+            for img in text.extract_iter(page, '<img id="image-', '>')
+        ]
+
+
+class ToonilyMangaExtractor(ToonilyBase, MangaExtractor):
+    """Extractor for manga from toonily.com"""
+    chapterclass = ToonilyChapterExtractor
+    pattern = r"(?:https?://)?(?:www\.)?toonily\.com(/webtoon/[^/?#]+)/?$"
+    example = "https://toonily.com/webtoon/MANGA"
+
+    def chapters(self, page):
+        if 'class="error404' in page:
+            raise exception.NotFoundError("manga")
+        data = self.metadata(page)
+        result = []
+        for chapter in text.extract_iter(
+                page, '<li class="wp-manga-chapter', "</li>"):
+            url , pos = text.extract(chapter, '<a href="', '"')
+            info, _ = text.extract(chapter, ">", "</a>", pos)
+            self.parse_chapter_string(info, data)
+            result.append((url, data.copy()))
+        return result
+
+    def metadata(self, page):
+        extr = text.extract_from(text.extr(
+            page, 'class="summary_content">', 'class="manga-action"'))
+        return {
+            "manga"      : text.extr(page, "<h1>", "</h1>").strip(),
+            "description": text.unescape(text.remove_html(text.extract(
+                page, ">", "</div>", page.index("summary__content"))[0])),
+            "rating"     : text.parse_float(
+                extr('total_votes">', "</span>").strip()),
+            "manga_alt"  : text.remove_html(
+                extr("Alternative </h5>\n</div>", "</div>")).split("; "),
+            "author"     : list(text.extract_iter(
+                extr('class="author-content">', "</div>"), '"tag">', "</a>")),
+            "artist"     : list(text.extract_iter(
+                extr('class="artist-content">', "</div>"), '"tag">', "</a>")),
+            "genres"     : list(text.extract_iter(
+                extr('class="genres-content">', "</div>"), '"tag">', "</a>")),
+            "type"       : text.remove_html(
+                extr("Type </h5>\n</div>", "</div>")),
+            "release"    : text.parse_int(text.remove_html(
+                extr("Release </h5>\n</div>", "</div>"))),
+            "status"     : text.remove_html(
+                extr("Status </h5>\n</div>", "</div>")),
+        }

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -132,6 +132,7 @@ CATEGORY_MAP = {
     "thatpervert"    : "ThatPervert",
     "thebarchive"    : "The /b/ Archive",
     "thecollection"  : "The /co/llection",
+    "toonily"      : "Toonily",
     "tumblrgallery"  : "TumblrGallery",
     "vanillarock"    : "もえぴりあ",
     "vidyart2"       : "/v/idyart2",

--- a/test/results/toonily.py
+++ b/test/results/toonily.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from gallery_dl.extractor import toonily
+from gallery_dl import exception
+
+
+__tests__ = (
+{
+    "#url"     : "https://toonily.com/webtoon/such-a-cute-spy/chapter-36/",
+    "#category": ("", "toonily", "chapter"),
+    "#class"   : toonily.ToonilyChapterExtractor,
+    "#pattern" : r"https://toonily\.com/wp-content/uploads/WP-manga/data/manga_[^/]+/[^/]+/[^.]+\.\w+",
+    "#count"   : 11,
+
+    "manga"        : "Jinxed",
+    "title"        : "",
+    "chapter"      : 36,
+    "tags"         : ["harem"],
+    "lang"         : "en",
+    "language"     : "English",
+},
+
+{
+    "#url"     : "https://toonily.com/webtoon/such-a-cute-spy/chapter-1000000/",
+    "#category": ("", "toonily", "chapter"),
+    "#class"   : toonily.ToonilyChapterExtractor,
+    "#exception": exception.NotFoundError,
+},
+
+{
+    "#url"     : "https://toonily.com/webtoon/such-a-cute-spy",
+    "#category": ("", "toonily", "manga"),
+    "#class"   : toonily.ToonilyMangaExtractor,
+    "#pattern" : r"https://toonily\.com/webtoon/such-a-cute-spy/chapter-\d+([_-].+)?/",
+    "#count"   : ">= 13",
+
+    "manga"      : "Such a Cute Spy",
+    "author"     : ["Life of Ruin"],
+    "artist"     : ["Ganghyeon Yeo"],
+    "genres"     : [
+        "Action",
+        "Comedy",
+        "Romance",
+        "School Life",
+    ],
+    "rating"     : float,
+    "status"     : "End",
+    "lang"       : "en",
+    "language"   : "English",
+    "manga_alt"  : list,
+},
+
+{
+    "#url"     : "https://toonily.com/manga/doesnotexist",
+    "#category": ("", "toonily", "manga"),
+    "#class"   : toonily.ToonilyMangaExtractor,
+    "#exception": exception.HttpError,
+},
+
+)

--- a/test/results/toonily.py
+++ b/test/results/toonily.py
@@ -55,7 +55,7 @@ __tests__ = (
 },
 
 {
-    "#url"     : "https://toonily.com/manga/doesnotexist",
+    "#url"     : "https://toonily.com/webtoon/doesnotexist",
     "#category": ("", "toonily", "manga"),
     "#class"   : toonily.ToonilyMangaExtractor,
     "#exception": exception.HttpError,


### PR DESCRIPTION
Toonily uses the same CDN as mangaread.org (WordPressMadara) so this is pretty much a copy-paste of the mangaread extractor. 

I've tested it locally and seems to work, but I'm not sure about the test results in test/results/toonlily.py
