### PR TITLE
[mastodon] fix handling null 'moved' account field

### DIFF
--- a/gallery_dl/extractor/mastodon.py
+++ b/gallery_dl/extractor/mastodon.py
@@ -70,7 +70,11 @@ class MastodonExtractor(BaseExtractor):
 
     def _check_moved(self, account):
         self._check_moved = None
-        if "moved" in account:
+        # Certain fediverse software (such as Iceshrimp and Sharkey) have a
+        # null account "moved" field instead of not having it outright.
+        # To handle this, check if the "moved" value is truthy instead
+        # if only it exists.
+        if account.get("moved"):
             self.log.warning("Account '%s' moved to '%s'",
                              account["acct"], account["moved"]["acct"])
 

--- a/test/results/mastodon.py
+++ b/test/results/mastodon.py
@@ -18,4 +18,15 @@ __tests__ = (
     "instance_remote": None,
 },
 
+{
+    "#url"     : "mastodon:https://wanderingwires.net/@quarc/9qppkxzyd1ee3i9p",
+    "#comment" : "null moved account",
+    "#category": ("mastodon", "wanderingwires.net", "status"),
+    "#class"   : mastodon.MastodonStatusExtractor,
+    "#urls"    : "https://s3.wanderingwires.net/null/4377e826-72ab-4659-885c-fa12945eb207.png",
+
+    "instance": "wanderingwires.net",
+    "instance_remote": None,
+},
+
 )


### PR DESCRIPTION
Examples:
- https://wanderingwires.net/@quarc/9qppkxzyd1ee3i9p
- https://void.rehab/@mia/9qqz5hl5yauvqwq5
- https://transgirl.cafe/@izzie/9octesgee0tz01ov