### PR TITLE
[instagram] Don't check private status for *.../YOU/following*

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -573,7 +573,7 @@ class InstagramFollowingExtractor(InstagramExtractor):
     example = "https://www.instagram.com/USER/following/"
 
     def items(self):
-        uid = self.api.user_id(self.item)
+        uid = self.api.user_id(self.item, check_private=False)
         for user in self.api.user_following(uid):
             user["_extractor"] = InstagramUserExtractor
             url = "{}/{}".format(self.root, user["username"])


### PR DESCRIPTION
When grabbing `https://www.instagram.com/YOU/following` we don't need to check/back off if *YOU* is a private account.