### PR TITLE
[instagram] default posts `like_count` to zero

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -165,7 +165,7 @@ class InstagramExtractor(Extractor):
             data = {
                 "post_id" : post["pk"],
                 "post_shortcode": post["code"],
-                "likes": post.get("like_count"),
+                "likes": post.get("like_count", 0),
                 "pinned": post.get("timeline_pinned_user_ids", ()),
                 "date": text.parse_timestamp(post.get("taken_at")),
             }


### PR DESCRIPTION
I don't know when/why this happens and for private account reasons can't add an example here, but i had this error out and it feels like a safe fix to default to `0` here.