### PR TITLE
[generic] use tempfile when saving cookies

### DIFF
--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -431,8 +431,9 @@ class Extractor():
                 return
 
         try:
-            with open(path, "w") as fp:
+            with open(path + ".tmp", "w") as fp:
                 util.cookiestxt_store(fp, self.cookies)
+            os.replace(path + ".tmp", path)
         except OSError as exc:
             self.log.warning("cookies: %s", exc)
 


### PR DESCRIPTION
If gallery-dl fails to write updated cookies, for example because the disk is full, on some systems it leaves behind an empty file, wiping out the existing cookies. To fix this, write the updated cookies to a temporary file first, then rename over the original cookies file.