### PR TITLE
Add warnings flag

### DIFF
--- a/gallery_dl/__init__.py
+++ b/gallery_dl/__init__.py
@@ -113,7 +113,7 @@ def main():
 
         # loglevels
         output.configure_logging(args.loglevel)
-        if args.loglevel >= logging.ERROR:
+        if args.loglevel >= logging.WARNING:
             config.set(("output",), "mode", "null")
             config.set(("downloader",), "progress", None)
         elif args.loglevel <= logging.DEBUG:

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -250,16 +250,16 @@ def build_parser():
         help="Activate quiet mode",
     )
     output.add_argument(
+        "-w", "--warning",
+        dest="loglevel",
+        action="store_const", const=logging.WARNING,
+        help="Print only warnings and errors",
+    )
+    output.add_argument(
         "-v", "--verbose",
         dest="loglevel",
         action="store_const", const=logging.DEBUG,
         help="Print various debugging information",
-    )
-    output.add_argument(
-        "-w", "--warning",
-        dest="loglevel",
-        action="store_const", const=logging.WARNING,
-        help="Print warnings",
     )
     output.add_argument(
         "-g", "--get-urls",

--- a/gallery_dl/option.py
+++ b/gallery_dl/option.py
@@ -256,6 +256,12 @@ def build_parser():
         help="Print various debugging information",
     )
     output.add_argument(
+        "-w", "--warning",
+        dest="loglevel",
+        action="store_const", const=logging.WARNING,
+        help="Print warnings",
+    )
+    output.add_argument(
         "-g", "--get-urls",
         dest="list_urls", action="count",
         help="Print URLs instead of downloading",


### PR DESCRIPTION
This commit adds a warnings flag

It can be combined with -q / --quiet to display warnings. The intent is to provide a silent option that still surfaces warning and error messages so that they are visible in logs.

I'm not entirely sure if this is the best approach or if there's already an existing way to accomplish this but with this I can run `gallery-dl -q -w` and I get silent output but still see warnings.  Essentially, I want an option that's in-between -q and -v, -v is too noisy. I only want to see warning messages and error messages.