### PR TITLE
[mastodon] Use boolean instead of integer keys for accounts/statuses endpoint

### DIFF
--- a/gallery_dl/extractor/mastodon.py
+++ b/gallery_dl/extractor/mastodon.py
@@ -227,8 +227,8 @@ class MastodonAPI():
                          exclude_replies=False):
         """Fetch an account's statuses"""
         endpoint = "/v1/accounts/{}/statuses".format(account_id)
-        params = {"only_media"     : "1" if only_media else "0",
-                  "exclude_replies": "1" if exclude_replies else "0"}
+        params = {"only_media"     : "true" if only_media else "false",
+                  "exclude_replies": "true" if exclude_replies else "false"}
         return self._pagination(endpoint, params)
 
     def status(self, status_id):


### PR DESCRIPTION
According to the mastodon API documentation the `only_media` and `exclude_replies` parameters must be boolean:

> only_media
Boolean. Filter out statuses without attachments.
exclude_replies
Boolean. Filter out statuses in reply to a different account.

https://docs.joinmastodon.org/methods/accounts/#query-parameters

The current implementation passes them as integers which causes issues with other services that implement the mastodon API, in my case Mitra instances.