### PR TITLE
optimize _find_most_recently_used_file for exact profile

### DIFF
--- a/gallery_dl/cookies.py
+++ b/gallery_dl/cookies.py
@@ -1001,6 +1001,12 @@ def _decrypt_windows_dpapi(ciphertext):
 
 
 def _find_most_recently_used_file(root, filename):
+    # if the provided root points to an exact profile path
+    # check if it contains the wanted filename
+    first_choice = os.path.join(root, filename)
+    if os.path.exists(first_choice):
+        return first_choice
+
     # if there are multiple browser profiles, take the most recently used one
     paths = []
     for curr_root, dirs, files in os.walk(root):


### PR DESCRIPTION
When reading cookies from the browser, the user is able to give either just the browser name, or also provide profile/container information.

If an exact profile is provided, there is no need to find the latest profile with `os.walk` which is very expensive.

This change optimizes that case and the performance increase is significant (~8 sec to 0.6 sec).

```
$ time gallery-dl --config-ignore -d . -D . --cookies-from-browser FIREFOX https://imgur.com/OO4UNqJ
[cookies][info] Extracted 16 cookies from Firefox
 ./imgur_OO4UNqJ.jpg

real    0m8.429s
user    0m0.216s
sys     0m0.431s

$ time gallery-dl --config-ignore -d . -D . --cookies-from-browser FIREFOX:bgamf5r6.default-release https://imgur.com/OO4UNqJ
[cookies][info] Extracted 16 cookies from Firefox
 ./imgur_OO4UNqJ.jpg

real    0m0.456s
user    0m0.183s
sys     0m0.011s

$ gallery-dl --version
1.26.9
```