### PR TITLE
[twitter] Match "/video/" Tweet URLs

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -749,7 +749,7 @@ class TwitterTweetExtractor(TwitterExtractor):
     """Extractor for individual tweets"""
     subcategory = "tweet"
     pattern = (BASE_PATTERN + r"/([^/?#]+|i/web)/status/(\d+)"
-               r"/?(?:$|\?|#|photo/)")
+               r"/?(?:$|\?|#|photo/|video/)")
     example = "https://twitter.com/USER/status/12345"
 
     def __init__(self, match):

--- a/test/results/twitter.py
+++ b/test/results/twitter.py
@@ -540,6 +540,13 @@ You’ll be able to receive four Galarian form Pokémon with Hidden Abilities, p
 },
 
 {
+    "#url"     : "https://twitter.com/perrypumas/status/1065692031626829824/video/1",
+    "#comment" : "/video/ URL",
+    "#category": ("", "twitter", "tweet"),
+    "#class"   : twitter.TwitterTweetExtractor,
+},
+
+{
     "#url"     : "https://twitter.com/morino_ya/status/1392763691599237121",
     "#comment" : "retweet with missing media entities (#1555)",
     "#category": ("", "twitter", "tweet"),


### PR DESCRIPTION
Those can be spotted when opening or copying links from the Media tab of an account.