### PR TITLE
Enable `user_has_liked` as IG download filter

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -168,6 +168,7 @@ class InstagramExtractor(Extractor):
                 "likes": post.get("like_count", 0),
                 "pinned": post.get("timeline_pinned_user_ids", ()),
                 "date": text.parse_timestamp(post.get("taken_at")),
+                "user_has_liked": post.get('has_liked', False),
             }
 
             caption = post["caption"]


### PR DESCRIPTION
Background and context:

1. Instagram by default requires you to be logged in.
2. Your account can LIKE posts.
3. Getting all of your likes from IG can be a pain.

As an active IG user, I want to be able to download only posts I've liked.

The information of whether or not your logged-in user has liked the target post is available in the API results, but was not available to the end-user for filtering.

This small change allows `user_has_liked` to be used to e.g. download only liked posts of an entire IG account.

Example use:

```
# Configuration must include e.g.
# --cookies-from-browser FIREFOX or however you are logging in

$ gallery-dl --filter 'user_has_liked' https://www.instagram.com/imgur/
```

This will only download the posts that have `has_liked: True` set in the returned REST API data.

Note: it will still need to loop through the entire account's posts since this is done per-post basis instead of looping just the liked posts, but at least you are able to use this IG feature as a download marker.