### PR TITLE
[docs] Automatically link to latest executables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,9 @@ Standalone Executable
 Prebuilt executable files with a Python interpreter and
 required Python packages included are available for
 
-- `Windows <https://github.com/mikf/gallery-dl/releases/download/v1.26.9/gallery-dl.exe>`__
+- `Windows <https://github.com/mikf/gallery-dl/releases/latest/download/gallery-dl.exe>`__
   (Requires `Microsoft Visual C++ Redistributable Package (x86) <https://aka.ms/vs/17/release/vc_redist.x86.exe>`__)
-- `Linux   <https://github.com/mikf/gallery-dl/releases/download/v1.26.9/gallery-dl.bin>`__
+- `Linux   <https://github.com/mikf/gallery-dl/releases/latest/download/gallery-dl.bin>`__
 
 
 Nightly Builds


### PR DESCRIPTION
No need to update the README every release