### PR TITLE
fix: extractor for speakerdeck.com

### DIFF
--- a/gallery_dl/extractor/speakerdeck.py
+++ b/gallery_dl/extractor/speakerdeck.py
@@ -10,6 +10,7 @@
 
 from .common import Extractor, Message
 from .. import text
+import re
 
 
 class SpeakerdeckPresentationExtractor(Extractor):
@@ -60,4 +61,5 @@ class SpeakerdeckPresentationExtractor(Extractor):
         """Extract and return a list of all image-urls"""
         page = self.request("https://speakerdeck.com/player/" +
                             self.presentation_id).text
+        page = re.sub(r"\s+", " ", page)
         return list(text.extract_iter(page, 'js-sd-slide" data-url="', '"'))


### PR DESCRIPTION
Current HTML of speakerdeck is like 
```html
          <div class="sd-player-slide js-sd-slide"
              data-url="http://...
```

So, the current extractor does not work because it can not handle line breaks and leading spaces.
With this PR,  the extractor can simply ignore them.