### PR TITLE
fixes #5746

### DIFF
--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -26,7 +26,7 @@ class KemonopartyExtractor(Extractor):
     root = "https://kemono.su"
     directory_fmt = ("{category}", "{service}", "{user}")
     filename_fmt = "{id}_{title[:180]}_{num:>02}_{filename[:180]}.{extension}"
-    archive_fmt = "{service}_{user}_{id}_{num}"
+    archive_fmt = "{service}_{user}_{id}_{filename}_{extension}_{num}"
     cookies_domain = ".kemono.su"
 
     def __init__(self, match):


### PR DESCRIPTION
fixes #5746
[kemonoparty] uses more unique entries for the sqlite3 archive to ensure that some revisions will not generate the same entry and thus skip their downloading