### PR TITLE
Fix subscribestar date parsing in udated posts

### DIFF
--- a/gallery_dl/extractor/subscribestar.py
+++ b/gallery_dl/extractor/subscribestar.py
@@ -127,6 +127,8 @@ class SubscribestarExtractor(Extractor):
         }
 
     def _parse_datetime(self, dt):
+        if dt.startswith("Updated on "):
+            dt = dt[11:]
         date = text.parse_datetime(dt, "%b %d, %Y %I:%M %p")
         if date is dt:
             date = text.parse_datetime(dt, "%B %d, %Y %I:%M %p")


### PR DESCRIPTION
Very basic solution to the bug where gallery-dl does not parse correctly the date on updated posts because of the "Updated on " prefix. This simply detects and remove the prefix before the parsing. 
