### PR TITLE
path.py - fix system cannot move file to different drive

### DIFF
--- a/gallery_dl/path.py
+++ b/gallery_dl/path.py
@@ -335,13 +335,10 @@ class PathFormat():
 
         if self.temppath != self.realpath:
             # Move temp file to its actual location
+            os.makedirs(self.realdirectory, exist_ok=True)
             while True:
                 try:
                     os.replace(self.temppath, self.realpath)
-                except FileNotFoundError:
-                    # delayed directory creation
-                    os.makedirs(self.realdirectory)
-                    continue
                 except OSError:
                     # move across different filesystems
                     shutil.copyfile(self.temppath, self.realpath)


### PR DESCRIPTION
When the gallery-dl config file is set to download the temporary files into one disk drive and then the base-directory set in extractor is set to another drive, the way `path.py` copies the file to the target destination like [this on line 340](https://github.com/mikf/gallery-dl/blob/ea81fa985f6311d968481fde8eb2b0d582f6d0fa/gallery_dl/path.py#L340), it fails with the below error:

`OSError(18, 'The system cannot move the file to a different disk drive')`

Since this is an OSError, it will retry [on line 347](https://github.com/mikf/gallery-dl/blob/ea81fa985f6311d968481fde8eb2b0d582f6d0fa/gallery_dl/path.py#L347).

This will cause yet another error:

`Unable to download data:  FileNotFoundError: [Errno 2] No such file or directory`

To resolve this, we attempt to create the folder first before doing any move operations with the `exists_ok=True` flag so that in case the folder already exists it doesn't throw an exception.

sample config:

``` json
{
    "downloader": {
        "rate": "5M",
        "retries": 3,
        "timeout": 10.0,
        "part-directory": "./data/.tmp_download/",
        "mtime": false,
        "http": {
            "adjust-extensions": true
        }
    },
    "extractor": {
        "base-directory": "W:/gallery-dl/files",
        "archive": "./data/archives/{category}.sqlite3",
        "archive-prefix": "",
        "sleep": 1,
        "skip": "abort:20",
        "deviantart": {
            "client-id": null,
            "client-secret": null,
            "auto-watch": false,
            "auto-unwatch": false,
            "comments": false,
            "extra": false,
            "flat": true,
            "folders": false,
            "group": true,
            "include": "gallery",
            "journals": "html",
            "mature": true,
            "metadata": false,
            "original": true,
            "wait-min": 0
        }
    }
]
```