### PR TITLE
Numbers images obtained from imagefap by default.

### DIFF
--- a/gallery_dl/extractor/imagefap.py
+++ b/gallery_dl/extractor/imagefap.py
@@ -19,7 +19,7 @@ class ImagefapExtractor(Extractor):
     category = "imagefap"
     root = "https://www.imagefap.com"
     directory_fmt = ("{category}", "{gallery_id} {title}")
-    filename_fmt = "{category}_{gallery_id}_{filename}.{extension}"
+    filename_fmt = "{category}_{gallery_id}_{num:07}_{filename}.{extension}"
     archive_fmt = "{gallery_id}_{image_id}"
     request_interval = (2.0, 4.0)
 

--- a/gallery_dl/extractor/imagefap.py
+++ b/gallery_dl/extractor/imagefap.py
@@ -19,7 +19,7 @@ class ImagefapExtractor(Extractor):
     category = "imagefap"
     root = "https://www.imagefap.com"
     directory_fmt = ("{category}", "{gallery_id} {title}")
-    filename_fmt = "{category}_{gallery_id}_{num:07}_{filename}.{extension}"
+    filename_fmt = "{category}_{gallery_id}_{num:04}_{filename}.{extension}"
     archive_fmt = "{gallery_id}_{image_id}"
     request_interval = (2.0, 4.0)
 


### PR DESCRIPTION
Imagefap.com assigns (random?) numeric filenames to all of their images.  This means that the current default effectively shuffles each gallery randomly upon download.

The original filenames are listed on the gallery page below the corresponding images, but extracting those is a lot more work than just numbering the images.  This tiny fix will at least preserve the gallery ordering if not the original uploaded filenames and (IMHO) is a strict improvement on the existing default.

Fixes #1746