### PR TITLE
[flickr] reference the correct function

### DIFF
--- a/gallery_dl/extractor/flickr.py
+++ b/gallery_dl/extractor/flickr.py
@@ -519,7 +519,7 @@ class FlickrAPI(oauth.OAuth1API):
 
         if self.contexts:
             try:
-                photo.update(self.api.photos_getAllContexts(photo["id"]))
+                photo.update(self.photos_getAllContexts(photo["id"]))
             except Exception as exc:
                 self.log.warning(
                     "Unable to retrieve 'contexts' data for %s (%s: %s)",


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/mikf/gallery-dl/commit/e92a9ae34389bb1d429b75ee981dde770b962b36#diff-5741d04464e95eab8716d83190078fd31be0ad91fed8da24cd390b9447239d35R522.

Before the referenced commit, [the code read `photo.update(self.api.photos_getAllContexts(self.item_id))`](https://github.com/mikf/gallery-dl/commit/e92a9ae34389bb1d429b75ee981dde770b962b36#diff-5741d04464e95eab8716d83190078fd31be0ad91fed8da24cd390b9447239d35L81). After the commit, the code became the same ([see how the EXIF-related code above was updated correctly](https://github.com/mikf/gallery-dl/commit/e92a9ae34389bb1d429b75ee981dde770b962b36#diff-5741d04464e95eab8716d83190078fd31be0ad91fed8da24cd390b9447239d35R514)), referencing `self.api`, which doesn't exist in this new context, which completely breaks this functionality since that exception will always become a warning, when it really should've been caught while reviewing the changes:
![image](https://github.com/user-attachments/assets/a4a244ae-35e6-41eb-bf33-ccc30fe79e1d)
