### PR TITLE
[weasyl] Fix favourites extractor and add support for the readable URL format

### DIFF
--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -192,9 +192,11 @@ class WeasylFavoriteExtractor(WeasylExtractor):
             if not owner_login:
                 owner_login = text.extr(page, '<a href="/~', '"')
 
+            new_posts = False
             for submitid in text.extract_iter(page, "/submissions/", "/", pos):
                 if submitid == lastid:
                     continue
+                new_posts = True
                 lastid = submitid
                 submission = self.request_submission(submitid)
                 if self.populate_submission(submission):
@@ -202,6 +204,6 @@ class WeasylFavoriteExtractor(WeasylExtractor):
                     yield Message.Directory, submission
                     yield Message.Url, submission["url"], submission
 
-            if "&amp;nextid=" not in page:
+            if not new_posts:
                 return
             params["nextid"] = submitid

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -172,7 +172,11 @@ class WeasylFavoriteExtractor(WeasylExtractor):
         if self.userid is None and self.username is not None:
             new_url = self.root + f"/favorites/{self.username}"
             page = self.request(new_url).text
-            self.userid = text.extr(page, '<a class="more" href="/favorites?userid=', '&amp')
+            self.userid = text.extr(
+                page,
+                '<a class="more" href="/favorites?userid=',
+                '&amp'
+            )
 
         owner_login = lastid = None
         url = self.root + "/favorites"

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -170,7 +170,7 @@ class WeasylFavoriteExtractor(WeasylExtractor):
 
     def items(self):
         if self.userid is None and self.username is not None:
-            new_url = self.root + f"/favorites/{self.username}"
+            new_url = self.root + "/favorites/{}".format(self.username)
             page = self.request(new_url).text
             self.userid = text.extr(
                 page,

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -160,14 +160,20 @@ class WeasylJournalsExtractor(WeasylExtractor):
 class WeasylFavoriteExtractor(WeasylExtractor):
     subcategory = "favorite"
     directory_fmt = ("{category}", "{owner_login}", "Favorites")
-    pattern = BASE_PATTERN + r"favorites\?userid=(\d+)"
+    pattern = BASE_PATTERN + r"favorites(?:\?userid=(\d+)|\/([\w~-]+))"
     example = "https://www.weasyl.com/favorites?userid=12345"
 
     def __init__(self, match):
         WeasylExtractor.__init__(self, match)
         self.userid = match.group(1)
+        self.username = match.group(2)
 
     def items(self):
+        if self.userid is None and self.username is not None:
+            new_url = self.root + f"/favorites/{self.username}"
+            page = self.request(new_url).text
+            self.userid = text.extr(page, '<a class="more" href="/favorites?userid=', '&amp')
+
         owner_login = lastid = None
         url = self.root + "/favorites"
         params = {

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -159,7 +159,7 @@ class WeasylJournalsExtractor(WeasylExtractor):
 
 class WeasylFavoriteExtractor(WeasylExtractor):
     subcategory = "favorite"
-    directory_fmt = ("{category}", "{owner_login}", "Favorites")
+    directory_fmt = ("{category}", "{user}", "Favorites")
     pattern = BASE_PATTERN + r"favorites(?:\?userid=(\d+)|\/([\w~-]+))"
     example = "https://www.weasyl.com/favorites?userid=12345"
 

--- a/test/results/weasyl.py
+++ b/test/results/weasyl.py
@@ -92,4 +92,11 @@ __tests__ = (
     "#count"   : ">= 5",
 },
 
+{
+    "#url"     : "https://www.weasyl.com/favorites/furoferre",
+    "#category": ("", "weasyl", "favorite"),
+    "#class"   : weasyl.WeasylFavoriteExtractor,
+    "#count"   : ">= 5",
+}
+
 )


### PR DESCRIPTION
When you click favourites on Weasyl, it tends to go to the clean URL format:
https://www.weasyl.com/favorites/furoferre
Rather than the user ID format. 

The user ID format still works, but you click "more submissions" to get there:
https://www.weasyl.com/favorites?userid=184616&feature=submit

This change allows the extractor to use the clean URL format, as well as the user ID format. It just uses the first to get the user ID for the second.


I did notice btw that some accounts have character favourites and things, alongside submission favourites, for example this account just has character favourites:
https://www.weasyl.com/favorites/jaggy
and those are listed with `feature=char`:
https://www.weasyl.com/favorites?userid=12345&feature=char
But the weasyl extractors don't have support for characters anyway. But thought it notable