### PR TITLE
[inkbunny] Store Inkbunny favourites in the Favorites directory of the user

### DIFF
--- a/gallery_dl/extractor/inkbunny.py
+++ b/gallery_dl/extractor/inkbunny.py
@@ -132,6 +132,7 @@ class InkbunnyPoolExtractor(InkbunnyExtractor):
 class InkbunnyFavoriteExtractor(InkbunnyExtractor):
     """Extractor for inkbunny user favorites"""
     subcategory = "favorite"
+    directory_fmt = ("{category}", "{favs_username!l}", "Favorites")
     pattern = (BASE_PATTERN + r"/(?:"
                r"userfavorites_process\.php\?favs_user_id=(\d+)|"
                r"submissionsviewall\.php"
@@ -151,7 +152,17 @@ class InkbunnyFavoriteExtractor(InkbunnyExtractor):
             self.orderby = params.get("orderby", "fav_datetime")
 
     def metadata(self):
-        return {"favs_user_id": self.user_id}
+        # Lookup fav user ID as username
+        path = "/userfavorites_process.php?favs_user_id=" + self.user_id
+        url = self.root + path
+        page = self.request(url).text
+        user_link = text.extr(page, '<a rel="author"', '</a>')
+        favs_username = text.extr(user_link, 'href="/', '"')
+
+        return {
+            "favs_user_id": self.user_id,
+            "favs_username": favs_username,
+        }
 
     def posts(self):
         params = {


### PR DESCRIPTION
This little PR changes where Inkbunny images download, so they download into the directory of the user whose favourites are being downloaded, rather than in different directories for each submission. This makes it better match the favorites download for FA, and twitter and similar. (And matches the changes for Weasyl in #6113 )