### PR TITLE
[util] fix problems when keyword 'extension' is not set by extractors

### DIFF
--- a/gallery_dl/path.py
+++ b/gallery_dl/path.py
@@ -214,7 +214,7 @@ class PathFormat():
         self.kwdict = kwdict
         self.filename = self.temppath = self.prefix = ""
 
-        ext = kwdict["extension"]
+        ext = kwdict.get("extension", "")
         kwdict["extension"] = self.extension = self.extension_map(ext, ext)
 
     def set_extension(self, extension, real=True):


### PR DESCRIPTION
I'm writing a new extractor, finding that the extractor need to set the `extension` field manually, or it exits with following messages:
```
Traceback (most recent call last):
  File "/home/-/tools/gallery-dl/gallery_dl/job.py", line 152, in run
    self.dispatch(msg)
  File "/home/-/tools/gallery-dl/gallery_dl/job.py", line 195, in dispatch
    self.handle_url(url, kwdict)
  File "/home/-/tools/gallery-dl/gallery_dl/job.py", line 301, in handle_url
    pathfmt.set_filename(kwdict)
  File "/home/-/tools/gallery-dl/gallery_dl/path.py", line 217, in set_filename
    ext = kwdict["extension"]
KeyError: 'extension'
```
I further find that there is already a mechanism to automatically get the extension from mimetype when `extension` is not set, just interrupted by the codes below:
 <https://github.com/mikf/gallery-dl/blob/57da9ebfb5d53b3e1f729161a199d6f825a72a94/gallery_dl/job.py#L301>

So I fix it. I think it's a good idea to just let the `HttpDownloader` take over the `extension` keyword for all extractors.