### PR TITLE
[reddit] support user profile share links

### DIFF
--- a/gallery_dl/extractor/reddit.py
+++ b/gallery_dl/extractor/reddit.py
@@ -340,18 +340,19 @@ class RedditRedirectExtractor(Extractor):
     category = "reddit"
     subcategory = "redirect"
     pattern = (r"(?:https?://)?(?:"
-               r"(?:\w+\.)?reddit\.com/(?:(?:r)/([^/?#]+)))"
+               r"(?:\w+\.)?reddit\.com/(?:(r|u|user)/([^/?#]+)))"
                r"/s/([a-zA-Z0-9]{10})")
     example = "https://www.reddit.com/r/SUBREDDIT/s/abc456GHIJ"
 
     def __init__(self, match):
         Extractor.__init__(self, match)
-        self.subreddit = match.group(1)
-        self.share_url = match.group(2)
+        self.sub_type = "user" if match.group(1) == "u" else match.group(1)
+        self.subreddit = match.group(2)
+        self.share_url = match.group(3)
 
     def items(self):
-        url = "https://www.reddit.com/r/" + self.subreddit + "/s/" + \
-              self.share_url
+        url = "https://www.reddit.com/" + self.sub_type + "/" + \
+              self.subreddit + "/s/" + self.share_url
         data = {"_extractor": RedditSubmissionExtractor}
         response = self.request(url, method="HEAD", allow_redirects=False,
                                 notfound="submission")

--- a/test/results/reddit.py
+++ b/test/results/reddit.py
@@ -268,4 +268,20 @@ __tests__ = (
     "#pattern" : r"^https://www\.reddit\.com/r/analog/comments/179exao/photographing_the_recent_annular_eclipse_with_a",
 },
 
+{
+    "#url"     : "https://www.reddit.com/u/Tailhook91/s/w4yAMbtOYm",
+    "#comment" : "Mobile share URL, user submission",
+    "#category": ("", "reddit", "redirect"),
+    "#class"   : reddit.RedditRedirectExtractor,
+    "#pattern" : r"^https://www.reddit.com/user/Tailhook91/comments/znfxbr/prove_it/",
+},
+
+{
+    "#url"     : "https://www.reddit.com/user/Tailhook91/s/w4yAMbtOYm",
+    "#comment" : "Mobile share URL, user submission",
+    "#category": ("", "reddit", "redirect"),
+    "#class"   : reddit.RedditRedirectExtractor,
+    "#pattern" : r"^https://www.reddit.com/user/Tailhook91/comments/znfxbr/prove_it/",
+},
+
 )


### PR DESCRIPTION
Spiritual follow-up to #4693 (time sure flies). Adds support for Reddit Mobile share links to a submission on a user-subreddit, e.g. https://www.reddit.com/u/Tailhook91/s/w4yAMbtOYm (expands to https://www.reddit.com/user/Tailhook91/comments/znfxbr/prove_it/?share_id=vUXyyXldTYSt2GDd5_WBL).