### PR TITLE
[philomena] switch default ponybooru filter to get everything by default

### DIFF
--- a/gallery_dl/extractor/philomena.py
+++ b/gallery_dl/extractor/philomena.py
@@ -46,7 +46,7 @@ BASE_PATTERN = PhilomenaExtractor.update({
     "ponybooru": {
         "root": "https://ponybooru.org",
         "pattern": r"(?:www\.)?ponybooru\.org",
-        "filter_id": "2",
+        "filter_id": "3",
     },
     "furbooru": {
         "root": "https://furbooru.org",


### PR DESCRIPTION
The system filter mislabeled "Everything" hides 4 tags https://ponybooru.org/filters/2

There are [many public filters that don't hide anything](https://ponybooru.org/filters?fq=spoilered_count%3A0%2C+hidden_count%3A0), I just picked [the oldest one](https://ponybooru.org/filters/3).