### PR TITLE
Use Python 3.9 on Windows

### DIFF
--- a/.github/workflows/executables.yml
+++ b/.github/workflows/executables.yml
@@ -33,7 +33,7 @@ jobs:
           python-packages: "secretstorage"
         - os: "windows-2019"
           architecture: "x86"
-          python-version: "3.8"
+          python-version: "3.9"
           python-packages: "toml"
 
     steps:


### PR DESCRIPTION
Currently GitHub generates executables for Windows from Python 3.8, which has been EOL for more than 2 months now. This PR corrects it by building with Python 3.9 instead of an out of date Python.