### PR TITLE
[boosty] Added post attachment download

### DIFF
--- a/gallery_dl/extractor/boosty.py
+++ b/gallery_dl/extractor/boosty.py
@@ -123,7 +123,10 @@ class BoostyExtractor(Extractor):
 
                 elif type == "audio_file":
                     files.append(self._update_url(post, block))
-
+                
+                elif type == "file":
+                    files.append(self._update_url(post, block))
+                
                 else:
                     self.log.debug("%s: Unsupported data type '%s'",
                                    post["int_id"], type)

--- a/gallery_dl/extractor/boosty.py
+++ b/gallery_dl/extractor/boosty.py
@@ -123,10 +123,10 @@ class BoostyExtractor(Extractor):
 
                 elif type == "audio_file":
                     files.append(self._update_url(post, block))
-                
+
                 elif type == "file":
                     files.append(self._update_url(post, block))
-                
+
                 else:
                     self.log.debug("%s: Unsupported data type '%s'",
                                    post["int_id"], type)


### PR DESCRIPTION
This PR addresses the issue mentioned in [gallery-dl#2387](https://github.com/mikf/gallery-dl/issues/2387#issuecomment-2564671646). Contrary to my comment the issue wasn’t with the use of cdn.boosty.to it turned out to be a missing data type handler.