### PR TITLE
[boosty] added new direct message extractor

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -148,7 +148,7 @@ Consider all listed sites to potentially be NSFW.
 <tr>
     <td>Boosty</td>
     <td>https://www.boosty.to/</td>
-    <td>Subscriptions Feed, Followed Users, Media Files, Posts, User Profiles</td>
+    <td>DMs, Subscriptions Feed, Followed Users, Media Files, Posts, User Profiles</td>
     <td><a href="https://github.com/mikf/gallery-dl#cookies">Cookies</a></td>
 </tr>
 <tr>

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -211,6 +211,7 @@ SUBCATEGORY_MAP = {
         "posts": "",
     },
     "boosty": {
+        "direct-messages": "DMs",
         "feed": "Subscriptions Feed",
     },
     "civitai": {

--- a/test/results/boosty.py
+++ b/test/results/boosty.py
@@ -131,5 +131,24 @@ __tests__ = (
     "#auth"    : True,
 },
 
+{
+    "#url"     : "https://boosty.to/app/messages?dialogId=3598621",
+    "#class"   : boosty.BoostyDirectMessagesExtractor,
+    "#auth"    : True,
+    "#count"   : 7,
+
+    "count"    : 1,
+    "extension": "",
+    "file"     : dict,
+    "user"     : dict,
+
+    "post": {
+        "authorId": int,
+        "content" : list,
+        "date"    : "type:datetime",
+        "dialogId": 3598621,
+        "id"      : int,
+    },
+},
 
 )


### PR DESCRIPTION
Adds `BoostyDirectMessageExtractor` as a new feature to fetch and process Boosty direct messages, including attachments. Updates `BoostyAPI` with `dialog`, `dialog_messages`, and `_pagination_dialog` methods for direct message retrieval. Verified that all file types can be successfully downloaded to the best of my capacity.
There is possibly a way to always fetch the DMs, but the `_dispatch_extractors` function is a bit too complex for me at the moment. Let me know if adjustments are needed or if this is out of scope.