### PR TITLE
add support for not splitting "contains" value

### DIFF
--- a/gallery_dl/util.py
+++ b/gallery_dl/util.py
@@ -83,7 +83,7 @@ def unique_sequence(iterable):
 
 def contains(values, elements, separator=" "):
     """Returns True if at least one of 'elements' is contained in 'values'"""
-    if isinstance(values, str):
+    if isinstance(values, str) and separator is not None:
         values = values.split(separator)
 
     if not isinstance(elements, (tuple, list)):


### PR DESCRIPTION
I've encountered situations where I wanted to filter out images with a blacklist of words in the filename (e.g. "low res", "lr", "preview", as well as their capitalized version) and the filter gets verbose really quickly. The "contains" function would be perfect to avoid this, but as of now you are forced to split the "values" parameter, which makes it unusable for filenames and such, and only useful for tags.
This could be a possible enhancement, where if the third parameter "separator" is set to "None" then the value won't get split, extending the function purposes.