### PR TITLE
Kemono Party - Support /posts endpoint and Creator Tag Calls

### DIFF
--- a/test/results/kemonoparty.py
+++ b/test/results/kemonoparty.py
@@ -40,6 +40,21 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://kemono.su/patreon/user/3161935?tag=pin-up",
+    "#comment" : "'tag' query parameter",
+    "#category": ("", "kemonoparty", "patreon"),
+    "#class"   : kemonoparty.KemonopartyUserExtractor,
+    "#urls"    : (
+        "https://kemono.su/data/03/e6/03e62592c3b616b8906c1aaa130bd9ceaa24d7f601b31f90cc11956a57ca1d82.png",
+        "https://kemono.su/data/6a/9b/6a9b6d93dcb86c24a48def1bb93ce2a9ad77393941f3469d87d39400433cf825.png",
+        "https://kemono.su/data/2a/b8/2ab8ba30644249e9516afaea05d61c0de14591cb9d232a2dc249650eb1a9a759.jpg",
+        "https://kemono.su/data/b0/38/b03882c8b0ab3b1cf9fc658a2bb2f9ac6ad4f3449015311dcd2d7ee7f748db31.png",
+    ),
+
+    "tags": r"\bpin-up\b",
+},
+
+{
     "#url"     : "https://kemono.su/subscribestar/user/alcorart",
     "#category": ("", "kemonoparty", "subscribestar"),
     "#class"   : kemonoparty.KemonopartyUserExtractor,
@@ -379,7 +394,7 @@ __tests__ = (
     "#category": ("", "kemonoparty", "discord-server"),
     "#class"   : kemonoparty.KemonopartyDiscordServerExtractor,
     "#pattern" : kemonoparty.KemonopartyDiscordExtractor.pattern,
-    "#count"   : 15,
+    "#count"   : 26,
 },
 
 {


### PR DESCRIPTION
Hello,

I've added support for getting a creator that is filtered by a tag. The endpoint seems to be a legacy one as there is not an alternative.

I've also added some changes to support the /posts endpoint to work. It was failing if the config['metadata'] had been set due to it reaching out for a blank user/service id.

Fixed the pagination prematurely exiting also for those endpoints as they require a key for their results and the check was for the raw object. 