### PR TITLE
Add error messages in lofter extractor

### DIFF
--- a/gallery_dl/extractor/lofter.py
+++ b/gallery_dl/extractor/lofter.py
@@ -23,6 +23,8 @@ class LofterExtractor(Extractor):
 
     def items(self):
         for post in self.posts():
+            if post is None:
+                continue
             if "post" in post:
                 post = post["post"]
 
@@ -129,6 +131,9 @@ class LofterAPI():
             url, method="POST", params=params, data=data)
         info = response.json()
 
+        if info["meta"]["status"] == 4200:
+            raise exception.NotFoundError("blog")
+
         if info["meta"]["status"] != 200:
             self.extractor.log.debug("Server response: %s", info)
             raise exception.StopExtraction("API request failed")
@@ -141,6 +146,9 @@ class LofterAPI():
             posts = data["posts"]
 
             yield from posts
+
+            if data["offset"] < 0:
+                break
 
             if params["offset"] + len(posts) < data["offset"]:
                 break


### PR DESCRIPTION
1. Add 'NotFoundError' when the lofter blog returns a 404
2. Stop extractor if the blog is empty, because this returns {offset: -1} in the data which previously infinity-looped the extractor.
3. Prevents errors when the blog is locked, the posts in self.posts() are None