### PR TITLE
[kemonoparty] fix kemono api skipping latest posts

### DIFF
--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -516,8 +516,8 @@ class KemonoAPI():
         params = {"q": query, "o": offset}
         return itertools.chain(
             self._call(
-                endpoint, {"o": ""}
-            ) if (offset is None and query is None) else (),
+                endpoint + "/posts-legacy"
+            )["results"] if (offset is None and query is None) else (),
             self._pagination(endpoint, params, 50)
         )
 

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -571,7 +571,7 @@ class KemonoAPI():
 
     def _pagination(self, endpoint, params, batch=50, key=False):
         offset = text.parse_int(params.get("o"))
-        params["o"] = offset - offset % batch
+        params["o"] = (offset - offset % batch) if offset != 0 else ""
 
         while True:
             data = self._call(endpoint, params)
@@ -584,4 +584,4 @@ class KemonoAPI():
 
             if len(data) < batch:
                 return
-            params["o"] += batch
+            params["o"] = text.parse_int(params["o"]) + batch

--- a/gallery_dl/extractor/kemonoparty.py
+++ b/gallery_dl/extractor/kemonoparty.py
@@ -73,7 +73,7 @@ class KemonopartyExtractor(Extractor):
         post_rev_id_set = set()
 
         for post in posts:
-            post_rev_id = post.get("revision_id") or post["id"]
+            post_rev_id = (post["id"], post.get("revision_id"))
             if post_rev_id in post_rev_id_set:
                 continue
             post_rev_id_set.add(post_rev_id)


### PR DESCRIPTION
Making requests with either the offset (`o`) or query (`q`) parameters set to a blank string "`?o=`" for some reason fixes the problem where kemono API would skip posts that were just imported (see #6780).