### PR TITLE
[ytdl] add 'module-loction' option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5641,7 +5641,7 @@ Description
     `downloader.ytdl.raw-options`_ to ``true`` to suppress all output.
 
 
-downloader.ytdl.module
+downloader.ytdl.module-name
 ----------------------
 Type
     ``string``
@@ -5652,6 +5652,16 @@ Description
 
     Setting this to ``null`` will try to import ``"yt_dlp"``
     followed by ``"youtube_dl"`` as fallback.
+
+
+downloader.ytdl.module-location
+----------------------
+Type
+    ``string``
+Default
+    ``null``
+Description
+    Specified directory path to import the ``ytdl`` module from.
 
 
 downloader.ytdl.outtmpl

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -41,8 +41,9 @@ class YoutubeDLDownloader(DownloaderBase):
             ytdl_instance = self.ytdl_instance
             if not ytdl_instance:
                 try:
-                    module = ytdl.import_module(self.config("module-name"), 
-                                                self.config("module-location"))
+                    module_name = self.config("module-name")
+                    module_path = self.config("module-location")
+                    module = ytdl.import_module(module_name, module_path)
                 except (ImportError, SyntaxError) as exc:
                     self.log.error("Cannot import module '%s'",
                                    getattr(exc, "name", ""))

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -41,7 +41,7 @@ class YoutubeDLDownloader(DownloaderBase):
             ytdl_instance = self.ytdl_instance
             if not ytdl_instance:
                 try:
-                    module = ytdl.import_module(self.config("module"))
+                    module = ytdl.import_module(self.config("module-name"), self.config("module-location"))
                 except (ImportError, SyntaxError) as exc:
                     self.log.error("Cannot import module '%s'",
                                    getattr(exc, "name", ""))

--- a/gallery_dl/downloader/ytdl.py
+++ b/gallery_dl/downloader/ytdl.py
@@ -41,7 +41,8 @@ class YoutubeDLDownloader(DownloaderBase):
             ytdl_instance = self.ytdl_instance
             if not ytdl_instance:
                 try:
-                    module = ytdl.import_module(self.config("module-name"), self.config("module-location"))
+                    module = ytdl.import_module(self.config("module-name"), 
+                                                self.config("module-location"))
                 except (ImportError, SyntaxError) as exc:
                     self.log.error("Cannot import module '%s'",
                                    getattr(exc, "name", ""))

--- a/gallery_dl/ytdl.py
+++ b/gallery_dl/ytdl.py
@@ -11,15 +11,19 @@
 import re
 import shlex
 import itertools
+import sys
 from . import text, util, exception
 
+def import_module(module_name, module_location=None):
+    if module_location is not None and module_location not in sys.path:
+        sys.path.append(module_location)
 
-def import_module(module_name):
     if module_name is None:
         try:
             return __import__("yt_dlp")
         except (ImportError, SyntaxError):
             return __import__("youtube_dl")
+        
     return __import__(module_name.replace("-", "_"))
 
 

--- a/gallery_dl/ytdl.py
+++ b/gallery_dl/ytdl.py
@@ -14,6 +14,7 @@ import itertools
 import sys
 from . import text, util, exception
 
+
 def import_module(module_name, module_location=None):
     if module_location is not None and module_location not in sys.path:
         sys.path.append(module_location)
@@ -23,7 +24,6 @@ def import_module(module_name, module_location=None):
             return __import__("yt_dlp")
         except (ImportError, SyntaxError):
             return __import__("youtube_dl")
-        
     return __import__(module_name.replace("-", "_"))
 
 


### PR DESCRIPTION
this is an option to specify a directory to import either the yt-dlp or youtube-dl module from (meant to address this issue, which i encountered today after updating gallery-dl to the latest version: https://github.com/mikf/gallery-dl/issues/4729)

this change also renames the ytdl 'module' option to 'module-name' to prevent confusion as to what each of these 2 options do