### PR TITLE
[tiktok] Add retry mechanism to rehydration data extraction

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -113,13 +113,13 @@ class TiktokExtractor(Extractor):
                 # We failed to retrieve rehydration data. This happens
                 # relatively frequently when making many requests, so
                 # retry.
+                if tries >= self._retries:
+                    raise
                 tries += 1
                 self.log.warning("%s: Failed to retrieve rehydration data "
                                  "(%s/%s)", url.rpartition("/")[2], tries,
                                  self._retries)
                 self.sleep(self._timeout, "retry")
-                if tries >= self._retries:
-                    raise
 
     def _extract_audio(self, post):
         audio = post["music"]

--- a/test/results/tiktok.py
+++ b/test/results/tiktok.py
@@ -7,7 +7,8 @@
 from gallery_dl.extractor import tiktok
 
 PATTERN = r"https://p1[69]-[^/?#.]+\.tiktokcdn[^/?#.]*\.com/[^/?#]+/\w+~.*\.jpe?g"
-PATTERN_WITH_AUDIO = r"(?:" + PATTERN + r"|ytdl:http.+)"
+PATTERN_WITH_AUDIO = r"(?:" + PATTERN + r"|https://v\d+m?\.tiktokcdn[^/?#.]*\.com/[^?#]+\?[^/?#]+)"
+USER_PATTERN = r"(https://www.tiktok.com/@([\w_.-]+)/video/(\d+)|" + PATTERN + r")"
 
 
 __tests__ = (
@@ -17,7 +18,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -26,7 +27,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -35,7 +36,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -44,7 +45,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -53,7 +54,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -62,7 +63,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -71,7 +72,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -80,7 +81,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -89,7 +90,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#pattern"  : PATTERN,
-    "#options"  : {"videos": False},
+    "#options"  : {"videos": False, "audio": False},
 },
 
 {
@@ -97,7 +98,7 @@ __tests__ = (
     "#comment"   : "deleted post",
     "#category"  : ("", "tiktok", "post"),
     "#class"     : tiktok.TiktokPostExtractor,
-    "#options"   : {"videos": False},
+    "#options"   : {"videos": False, "audio": False},
     "count"      : 0,
 },
 
@@ -107,7 +108,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#urls"     : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
-    "#options"  : {"videos": True},
+    "#options"  : {"videos": True, "audio": True},
 },
 
 {
@@ -116,7 +117,7 @@ __tests__ = (
     "#category" : ("", "tiktok", "post"),
     "#class"    : tiktok.TiktokPostExtractor,
     "#urls"     : "ytdl:https://www.tiktok.com/@memezar/video/7449708266168274208",
-    "#options"  : {"videos": True},
+    "#options"  : {"videos": True, "audio": True},
 },
 
 {
@@ -241,17 +242,8 @@ __tests__ = (
     "#comment"  : "User profile",
     "#category" : ("", "tiktok", "user"),
     "#class"    : tiktok.TiktokUserExtractor,
-    "#pattern"  : PATTERN_WITH_AUDIO,
-    "#options"  : {"videos": True, "tiktok-range": "1-10"},
-},
-
-{
-    "#url"      : "https://www.tiktok.com/@chillezy/",
-    "#comment"  : "User profile without audio or videos",
-    "#category" : ("", "tiktok", "user"),
-    "#class"    : tiktok.TiktokUserExtractor,
-    "#pattern"  : PATTERN,
-    "#options"  : {"videos": False, "tiktok-range": "1-10"},
+    "#pattern"  : USER_PATTERN,
+    "#options"  : {"videos": True, "audio": True, "tiktok-range": "1-10"},
 },
 
 {


### PR DESCRIPTION
If you make 1000s+ of requests in a short duration of time, TikTok will refuse to publish rehydration data with a video page. This can happen quite frequently even when downloading just a few large user profiles. This PR attempts to address this by adding a retry and timeout mechanism to `_extract_rehydration_data()`.

Some other observations I've made:

- If a single link raises an exception when downloading a user page, I am of the opinion that it shouldn't cause the rest of the profile download to fail. But unsure how best to implement this.
- It would be nice to have some generic feature that prints all failed links at the end of processing, is there a feature that already supports this (not just reporting that a user profile failed to download fully, but reporting which links within that profile failed to download)? I've found `--error-file`, but that will only report the user's page as the error and not any of the links extracted from it that may have failed.

I wonder if both points could be covered by requeueing all of the links extracted from `yt-dlp` when downloading a user page? That way hopefully each link can be treated separately and they won't cause any other links to fail or get dropped. Additionally, we could use the `--sleep-extractor` option to sleep in between each user profile's post which I think is a lot more intuitive than what this PR introduces (especially as the `--retries` and `--http-timeout` options relate to networking/HTTP requests and not sleeping/retrying in the extractor).

I've tried `yield`ing a `Url` for each video from a user profile instead of returning the list of URLs, and that doesn't end up creating a list of failed links unfortunately.

@mikf I'd like to hear your thoughts on these issues, and I'd like to perform more testing of my own, before merging this in-progress branch.

Closes: #7098