### PR TITLE
[DeviantArt] Support for Subfolders

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2286,6 +2286,16 @@ Description
     | Leave ``SIZE`` empty to download the regular, small avatar format.
 
 
+extractor.deviantart.folder.subfolders
+--------------------------------------
+Type
+    ``bool``
+Default
+    ``true``
+Description
+    Also extract subfolder content.
+
+
 extractor.discord.embeds
 ------------------------
 Type

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -235,6 +235,9 @@
 
             "avatar": {
                 "formats": null
+            },
+            "folder": {
+                "subfolders": true
             }
         },
         "exhentai":

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1018,7 +1018,7 @@ class DeviantartFolderExtractor(DeviantartExtractor):
                                       "{folder[parent_folder]}",
                                       "{folder[title]}")
 
-        if folder.get("has_subfolders"):
+        if folder.get("has_subfolders") and self.config("subfolders", True):
             for subfolder in folder["subfolders"]:
                 subfolder["parent_folder"] = folder["name"]
                 subfolder["subfolder"] = True

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -687,6 +687,10 @@ x2="45.4107524%" y2="71.4898596%" id="app-root-3">\
             for folder in folders:
                 if match(folder["name"]):
                     return folder
+                elif folder["has_subfolders"]:
+                    for subfolder in folder["subfolders"]:
+                        if match(subfolder["name"]):
+                            return subfolder
         else:
             for folder in folders:
                 if folder["folderid"] == uuid:

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1002,9 +1002,7 @@ class DeviantartFolderExtractor(DeviantartExtractor):
             "parent_uuid": folder["parent"],
         }
 
-        del folder["thumb"]
-
-        if folder.get('subfolder'):
+        if folder.get("subfolder"):
             self.folder["parent_folder"] = folder["parent_folder"]
             self.archive_fmt = "F_{folder[parent_uuid]}_{index}.{extension}"
 
@@ -1016,13 +1014,12 @@ class DeviantartFolderExtractor(DeviantartExtractor):
                                       "{folder[parent_folder]}",
                                       "{folder[title]}")
 
-        if folder['has_subfolders']:
+        if folder.get("has_subfolders"):
             for subfolder in folder["subfolders"]:
                 subfolder["parent_folder"] = folder["name"]
                 subfolder["subfolder"] = True
-
-            yield from self._folder_urls(folder['subfolders'],
-                                         "gallery", DeviantartFolderExtractor)
+            yield from self._folder_urls(
+                folder["subfolders"], "gallery", DeviantartFolderExtractor)
 
         yield from self.api.gallery(self.user, folder["folderid"], self.offset)
 

--- a/test/results/deviantart.py
+++ b/test/results/deviantart.py
@@ -351,6 +351,33 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://www.deviantart.com/avapithecus/gallery/71028779/drake-hero",
+    "#comment" : "main folder + subfolders",
+    "#category": ("", "deviantart", "folder"),
+    "#class"   : deviantart.DeviantartFolderExtractor,
+    "#options" : {"subfolders": True, "original": False, "image-range": "1"},
+    "#pattern" : (
+        r"https://www.deviantart.com/Avapithecus/gallery/6FCC57FA-F21D-14CC-5E0F-BB76479B6555/Folk Hero",
+        r"https://www.deviantart.com/Avapithecus/gallery/8D5E41B0-4BF5-649B-6620-B1D89C6D6BCE/Denizens of Suwarrow",
+        r"https://www.deviantart.com/Avapithecus/gallery/7FE4D499-E883-23D2-1659-1B64CA67358D/Beyond Suwarrow",
+        r"https://www.deviantart.com/Avapithecus/gallery/38AAB41C-F0F1-4DE9-6FB9-D3493CD77D01/The Drake Number",
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/c5e7b050-4923-4473-b8c0-ca0bc1c1b1fe/dgqc5py-3371d62e-465f-4b17-bd23-5005517fc68d.jpg/v1/fill/.+",
+    ),
+},
+
+{
+    "#url"     : "https://www.deviantart.com/avapithecus/gallery/87003033/the-drake-number",
+    "#comment" : "subfolder",
+    "#category": ("", "deviantart", "folder"),
+    "#class"   : deviantart.DeviantartFolderExtractor,
+    "#options" : {"original": False},
+    "#pattern" : (
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/c5e7b050-4923-4473-b8c0-ca0bc1c1b1fe/dfu7xyj-44d1a551-dbdc-4614-baee-82612fb044a6.jpg\?token=ey.+",
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/c5e7b050-4923-4473-b8c0-ca0bc1c1b1fe/deeoxic-932e966c-6d3b-473c-8053-ed7bad05813a.jpg/v1/fill/.+",
+    ),
+},
+
+{
     "#url"     : "https://shimoda7.deviantart.com/gallery/722019/Miscellaneous",
     "#category": ("", "deviantart", "folder"),
     "#class"   : deviantart.DeviantartFolderExtractor,


### PR DESCRIPTION
# Overview
Bumping the header version from `20200519` -> `20210526` which brings support for sub-folders in Gallery and Collections (allegedly). The Collections API doesn't *actually* expose sub-folders nor can I find an example of a collection folder.


> May 26th 2021
> Added new version 20210526
[/gallery/folders](https://www.deviantart.com/developers/http/v1/20240701/gallery_folders/f6104e0d969bbbdcf2154e4b221aa3a6) - Galleries now can display sub-folders
[/collections/folders](https://www.deviantart.com/developers/http/v1/20240701/collections_folders/35030a41b12db6c4edf6bf9b163e4327) - Collections now can display sub-folders


## Process
This will first iterate the `sub-folders` then proceed to do the main folder requested. I chose this path as it is not uncommon to have people put things in ***both*** the **main** and **sub-folder**. 

This logs into the archive by default with the ***parent*** folder uuid so that way the picture will be unique to a folder/sub-folder.

It flattens the folder structure by **default** just like the Gallery and Favorites using the 

## Questions
1. Do we want to add a config option to choose whether main folder vs sub-folders comes first? Or should we reverse the pattern currently?
2. Should there be a separate flag to flatten sub-folders (currently using the same `flat` option as the Gallery/Favorites).

Also a general question about how we want flatten to work - do we want to roll images up into the main folder or flatten the directory structure and move the sub-folders up to the main folders level?

```
> Deviant Art Folders
/MainFolder/SubFolder1/
/MainFolder/SubFolder2/

> Option A - Current Implementation
/MainFolder/<DEVIATIONS FROM MAIN AND SUB FOLDERS>

> Option B
/MainFolder/<DEVIATIONS>
/SubFolder1/<DEVIATIONS>
/SubFolder2/<DEVIATIONS>
```

## Tests
I am not sure how to setup a test currently for checking this (I'm still exploring that part of the repo). However here are two good examples for sub-folders (SFW)
> [Avapithecus](https://www.deviantart.com/avapithecus/gallery/71028779/drake-hero) - Some form of Hero Art
> [Bold Frontiers](https://www.deviantart.com/boldfrontiers/gallery/58825179/travel-canada) - Photography and been around for about 19 years

## Changes
1. Updated the `DeviantartFolderExtractor` to support sub-folders
2. Updated the `_find_folder` function to iterate over the sub-folders
3. Updated the header version to be `20210526`


Closes: #4988