### PR TITLE
[Instagram] Handle instagram.com/share/ URLs generated by the mobile app

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -707,11 +707,21 @@ class InstagramPostExtractor(InstagramExtractor):
     """Extractor for an Instagram post"""
     subcategory = "post"
     pattern = (r"(?:https?://)?(?:www\.)?instagram\.com"
-               r"/(?:[^/?#]+/)?(?:p|tv|reel)/([^/?#]+)")
+               r"/(?:share/()|[^/?#]+/)?(?:p|tv|reel)/([^/?#]+)")
     example = "https://www.instagram.com/p/abcdefg/"
 
     def posts(self):
-        return self.api.media(self.item)
+        share, shortcode = self.groups
+        if share is not None:
+            url = text.ensure_http_scheme(self.url)
+            headers = {
+                "Sec-Fetch-Dest": "empty",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "same-origin",
+            }
+            location = self.request_location(url, headers=headers)
+            shortcode = location.split("/")[-2]
+        return self.api.media(shortcode)
 
 
 class InstagramRestAPI():

--- a/test/results/instagram.py
+++ b/test/results/instagram.py
@@ -277,4 +277,18 @@ __tests__ = (
     "#class"   : instagram.InstagramPostExtractor,
 },
 
+{
+    "#url"     : "https://www.instagram.com/share/p/BACiUUUYQV",
+    "#category": ("", "instagram", "post"),
+    "#class"   : instagram.InstagramPostExtractor,
+    "shortcode"  : "C6q-XdvsU5v",
+},
+
+{
+    "#url"     : "https://www.instagram.com/share/reel/BARSSL4rTu",
+    "#category": ("", "instagram", "post"),
+    "#class"   : instagram.InstagramPostExtractor,
+    "shortcode"  : "DHbVbT4Jx0c",
+}
+
 )


### PR DESCRIPTION
As of december 2024, when copying the URL of a post from the Instagram Android app (I assume it's the same on other platforms) the real URL and tracking information are wrapped into a redirect formatted like: `https://www.instagram.com/share/reel/BARSSL4rTu`

The real post shortcode is not the same. Making a GET on this URL with proper Sec-Fetch headers, Instagram gives a code 302 response, with the real URL in the Location headers.

This is my first contributions, I'm not sure about the PR rules, and I'm not a python dev. Let me know if I need to make any changes. The security headers were copied from the Facebook extractor. I removed the /guide test as that instagram feature no longer exist.