### PR TITLE
[DeviantArt] - Multi Image Gallery

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1290,8 +1290,8 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
 
         deviation["img_count"] = 1 + len(additional_media)
         deviation["num"] = 1
-
         yield deviation
+
         for index, post in enumerate(additional_media):
             uri = post['media']['baseUri'].encode().decode('unicode-escape')
             deviation["content"]["src"] = uri

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1280,7 +1280,8 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
         _dev_info = text.extr(
             page, '\\"deviationExtended\\":', ',\\"deviation\\":', None)
         # Clean up escaped quotes
-        _json_str = re.sub(r'(?<!\\)\\{1}"', '"', _dev_info).replace("\\'", "'")
+        _json_str = re.sub(
+            r'(?<!\\)\\{1}"', '"', _dev_info).replace("\\'", "'")
         _extended_info = json.loads(_json_str)[self.deviation_id]
         additional_media = _extended_info.get('additionalMedia', [])
 

--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -1287,7 +1287,7 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
         if len(additional_media) > 0:
             self.filename_fmt = \
                 "{category}_{index}_{title}_{num:>02}.{extension}"
-        deviation["is_downloadable"] = True
+
         deviation["img_count"] = 1 + len(additional_media)
         deviation["num"] = 1
 

--- a/test/results/deviantart.py
+++ b/test/results/deviantart.py
@@ -902,6 +902,25 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://www.deviantart.com/justatest235723/art/1133021832",
+    "#comment" : "mutliple images (#6653)",
+    "#category": ("", "deviantart", "deviation"),
+    "#class"   : deviantart.DeviantartDeviationExtractor,
+    "#archive" : False,
+    "#pattern" : (
+        r"https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/940f2d05-c5eb-4917-8192-7eb6a2d508c6/diqkl8o-235680f0-7746-485c-9022-6042ab1f4d50\.png\?token=ey.+",
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/940f2d05-c5eb-4917-8192-7eb6a2d508c6/diqkl8o-a47549b4-427d-404d-9a39-64cc07c6b5fb\.png",
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/940f2d05-c5eb-4917-8192-7eb6a2d508c6/diqkl8o-faac0af6-ef9b-4c49-82af-349ba9f4acf7\.png",
+        r"https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/940f2d05-c5eb-4917-8192-7eb6a2d508c6/diqkl8o-34396355-d67d-4069-987f-b80f25495635\.png",
+    ),
+
+    "index"     : 1133021832,
+    "index_file": {0, 810469878, 810469899, 810469922},
+    "count"     : 4,
+    "num"       : range(1, 4),
+},
+
+{
     "#url"     : "https://deviantart.com/view/904858796/",
     "#comment" : "/view/ URLs",
     "#category": ("", "deviantart", "deviation"),


### PR DESCRIPTION
# Overview
Adding support for multi image galleries. Currently there is no oAuth endpoint that returns this information - however the `deviationExtended` info that is found on the initial page load does have this information.


## Process
This will capture the information from the `additionalMedia` key on the `deviationExtended` metadata. I've added a few pieces of metadata to deviations:

1. `img_count` - number of images in total for the deviation page
2. `num` - What position the image is on the page

The default filename will use the `deviation_id` for the first image and the `fileId` for the subsequent images to make sure they are unique. This is done by updating the `index` value for the deviation.

## Tests
Example gallery that can be used for testing (SFW)

> [October Fest](https://www.deviantart.com/comestomindart/art/October-Fest-Tavern-1169577802)

## Changes
1. Updated the `DeviantartDeviationExtractor` to support multi images in the galleries
