### PR TITLE
[pixiv] add support for phixiv.net URLs

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 import itertools
 import hashlib
 
-BASE_PATTERN = r"(?:https?://)?(?:www\.|touch\.)?pixiv\.net"
+BASE_PATTERN = r"(?:https?://)?(?:www\.|touch\.)?ph?ixiv\.net"
 USER_PATTERN = BASE_PATTERN + r"/(?:en/)?users/(\d+)"
 
 


### PR DESCRIPTION
I'm seeing these fairly often on Discord, so I thought it'd be a good idea to add support for [phixiv.net](https://github.com/thelaao/phixiv) URLs.