### PR TITLE
Enhancement filter event

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6647,6 +6647,8 @@ Description
         After a file got moved to its target location
     ``skip``
         When skipping a file download
+    ``filter``
+        When a file is filtered (image-filter or chapter-filter)
     ``error``
         After a file download failed
     ``post``

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -188,6 +188,7 @@ class Job():
 
     def dispatch(self, msg):
         """Call the appropriate message handler"""
+        _filtered = False
         if msg[0] == Message.Url:
             _, url, kwdict = msg
             if self.metadata_url:
@@ -195,6 +196,8 @@ class Job():
             if self.pred_url(url, kwdict):
                 self.update_kwdict(kwdict)
                 self.handle_url(url, kwdict)
+            else:
+                _filtered = True
 
         elif msg[0] == Message.Directory:
             self.update_kwdict(msg[1])
@@ -206,6 +209,13 @@ class Job():
                 kwdict[self.metadata_url] = url
             if self.pred_queue(url, kwdict):
                 self.handle_queue(url, kwdict)
+            else:
+                _filtered = True
+
+        if _filtered:
+            if 'filter' in self.hooks:
+                for callback in self.hooks['filter']:
+                    callback(self.pathfmt)
 
     def handle_url(self, url, kwdict):
         """Handle Message.Url"""

--- a/gallery_dl/job.py
+++ b/gallery_dl/job.py
@@ -212,7 +212,7 @@ class Job():
             else:
                 _filtered = True
 
-        if _filtered:
+        if _filtered and hasattr(self, 'hooks'):
             if 'filter' in self.hooks:
                 for callback in self.hooks['filter']:
                     callback(self.pathfmt)


### PR DESCRIPTION
# Overview

Adding a new hook for when something has been filtered out. When using `image-filter`/`image-unique` or `chapter-filter`/`chapter-unique` the process will just skip doing the download and there is no event to check for this any form of `skip`, `after`, etc. 

# Changes

Added a local variable to check if a `msg` was `filtered` for any reason.  Use of `hasattr(self, "hooks")` was necessary as only download jobs have the `self.hooks` so things like `KeywordJob` would throw errors as it doesn't check for hooks.