### PR TITLE
[weasyl] Set gallery-dl user agent to match danbooru user agent format, for weasyl

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -661,7 +661,7 @@ extractor.*.user-agent
 Type
     ``string``
 Default
-    * ``"gallery-dl/VERSION"``: ``[Danbooru]``, ``mangadex``
+    * ``"gallery-dl/VERSION"``: ``[Danbooru]``, ``mangadex``, ``weasyl``
     * ``"gallery-dl/VERSION (by mikf)"``: ``[E621]``
     * ``"Patreon/72.2.28 (Android; Android 14; Scale/2.10)"``: ``patreon``
     * ``"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/LATEST.0.0.0 Safari/537.36"``: ``instagram``

--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -7,7 +7,7 @@
 """Extractors for https://www.weasyl.com/"""
 
 from .common import Extractor, Message
-from .. import text
+from .. import text, util
 
 BASE_PATTERN = r"(?:https://)?(?:www\.)?weasyl.com/"
 
@@ -18,6 +18,7 @@ class WeasylExtractor(Extractor):
     filename_fmt = "{submitid} {title}.{extension}"
     archive_fmt = "{submitid}"
     root = "https://www.weasyl.com"
+    useragent = util.USERAGENT
 
     @staticmethod
     def populate_submission(data):


### PR DESCRIPTION
To fit with their bot ettiquette: https://projects.weasyl.com/bot-etiquette

They're happy for gallery-dl to access the site and all, but would like better transparency on it