### PR TITLE
 [pixiv] fix user details request not being cached, causing extra requests

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -69,7 +69,7 @@ class PixivExtractor(Extractor):
             files = self._extract_files(work)
 
             if self.meta_user:
-                work.update(self.api.user_detail(work["user"]["id"]))
+                work.update(self.api.user_detail(str(work["user"]["id"])))
             if self.meta_comments:
                 if work["total_comments"] and not work.get("_ajax"):
                     try:
@@ -881,7 +881,7 @@ class PixivNovelExtractor(PixivExtractor):
             novels = itertools.islice(novels, self.max_posts)
         for novel in novels:
             if self.meta_user:
-                novel.update(self.api.user_detail(novel["user"]["id"]))
+                novel.update(self.api.user_detail(str(novel["user"]["id"])))
             if self.meta_comments:
                 if novel["total_comments"]:
                     novel["comments"] = list(


### PR DESCRIPTION
The pixiv extractor has one cached function `user_detail`, which sends `/v1/user/detail` requests to the mobile API for user metadata. Calls to `user_detail` throughout the extractor code sometimes have an integer user_id and sometimes string. Since this argument is used as a key for caching this function, it would in some cases cause an extra request to be made, for example if the first call was cached with a string version of the user_id and the second used an integer. This commit adds a wrapper for the cached user_detail function that converts the user_id argument to an integer in all cases.

It's just a suggestion, so if another solution for the wrapper fits the codebase better or if it would be preferred that the user_id argument type is handled before calls to the function, then I will of course defer to that.

Since this is my first PR here, is it expected that you make an issue before doing so? I apologize for not providing a concrete example (I'm too lazy right now) of this double request, but I've implemented this change locally (and a few others for the pixiv extractor that I may elaborate on later) and it fixes this issue.

