### PR TITLE
[pixiv] Implement sanity handling for ugoira works

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -137,6 +137,8 @@ class PixivExtractor(Extractor):
                 if self.sanity_workaround:
                     body = self._request_ajax("/illust/" + str(work_id))
                     if work["type"] == "ugoira":
+                        if not self.load_ugoira:
+                            return ()
                         self.log.info("%s: Retrieving Ugoira AJAX metadata",
                                       work["id"])
                         try:

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -137,16 +137,16 @@ class PixivExtractor(Extractor):
                 if self.sanity_workaround:
                     body = self._request_ajax("/illust/" + str(work_id))
                     if work["type"] == "ugoira":
-                        self.log.warning(
-                            "Attempting to retrieve ugoira AJAX metadata.")
+                        self.log.info("%s: Retrieving Ugoira AJAX metadata",
+                                      work["id"])
                         try:
                             self._extract_ajax(work, body)
                             return self._extract_ugoira(work, url)
                         except Exception as exc:
+                            self.log.debug("", exc_info=exc)
                             self.log.warning(
-                                "%s: Unable to retrieve Ugoira metatdata "
-                                "(%s - %s)",
-                                work["id"], exc.__class__.__name__, exc)
+                                "%s: Unable to extract Ugoira URL. Provide "
+                                "logged-in cookies to access it", work["id"])
                     else:
                         return self._extract_ajax(work, body)
 

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -137,13 +137,15 @@ class PixivExtractor(Extractor):
                 if self.sanity_workaround:
                     body = self._request_ajax("/illust/" + str(work_id))
                     if work["type"] == "ugoira":
-                        self.log.warning("Attempting to retrieve ugoira AJAX metadata.")
+                        self.log.warning(
+                            "Attempting to retrieve ugoira AJAX metadata.")
                         try:
                             self._extract_ajax(work, body)
                             return self._extract_ugoira(work, url)
                         except Exception as exc:
                             self.log.warning(
-                                "%s: Unable to retrieve Ugoira metatdata (%s - %s)",
+                                "%s: Unable to retrieve Ugoira metatdata "
+                                "(%s - %s)",
                                 work["id"], exc.__class__.__name__, exc)
                     else:
                         return self._extract_ajax(work, body)
@@ -172,7 +174,8 @@ class PixivExtractor(Extractor):
 
     def _extract_ugoira(self, work, img_url):
         if work.get("_ajax"):
-            ugoira = self._request_ajax("/illust/" + str(work["id"]) + "/ugoira_meta")
+            ugoira = self._request_ajax(
+                "/illust/" + str(work["id"]) + "/ugoira_meta")
             img_url = ugoira["src"]
         else:
             ugoira = self.api.ugoira_metadata(work["id"])

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -136,7 +136,17 @@ class PixivExtractor(Extractor):
                 self.log.warning("%s: 'limit_sanity_level' warning", work_id)
                 if self.sanity_workaround:
                     body = self._request_ajax("/illust/" + str(work_id))
-                    return self._extract_ajax(work, body)
+                    if work["type"] == "ugoira":
+                        self.log.warning("Attempting to retrieve ugoira AJAX metadata.")
+                        try:
+                            self._extract_ajax(work, body)
+                            return self._extract_ugoira(work, url)
+                        except Exception as exc:
+                            self.log.warning(
+                                "%s: Unable to retrieve Ugoira metatdata (%s - %s)",
+                                work["id"], exc.__class__.__name__, exc)
+                    else:
+                        return self._extract_ajax(work, body)
 
             elif limit_type == "limit_mypixiv_360.png":
                 work["_mypixiv"] = True
@@ -161,7 +171,11 @@ class PixivExtractor(Extractor):
         return ()
 
     def _extract_ugoira(self, work, img_url):
-        ugoira = self.api.ugoira_metadata(work["id"])
+        if work.get("_ajax"):
+            ugoira = self._request_ajax("/illust/" + str(work["id"]) + "/ugoira_meta")
+            img_url = ugoira["src"]
+        else:
+            ugoira = self.api.ugoira_metadata(work["id"])
         work["_ugoira_frame_data"] = work["frames"] = frames = ugoira["frames"]
         work["_ugoira_original"] = self.load_ugoira_original
         work["_http_adjust_extension"] = False
@@ -198,7 +212,10 @@ class PixivExtractor(Extractor):
             ]
 
         else:
-            zip_url = ugoira["zip_urls"]["medium"]
+            if work.get("_ajax"):
+                zip_url = ugoira["originalSrc"]
+            else:
+                zip_url = ugoira["zip_urls"]["medium"]
             work["date_url"] = self._date_from_url(zip_url)
             url = zip_url.replace("_ugoira600x600", "_ugoira1920x1080", 1)
             return ({"url": url},)

--- a/test/results/pixiv.py
+++ b/test/results/pixiv.py
@@ -287,6 +287,14 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://www.pixiv.net/en/artworks/103841583",
+    "#comment" : "Ugoira limit_sanity_level_360.png (#4327 #6297 #7285)",
+    "#class"   : pixiv.PixivWorkExtractor,
+    "#auth"    : True,
+    "#urls"    : "https://i.pximg.net/img-zip-ugoira/img/2022/12/23/23/36/13/103841583_ugoira1920x1080.zip",
+},
+
+{
     "#url"     : "https://www.pixiv.net/en/artworks/104582860",
     "#comment" : "deleted limit_sanity_level_360.png work (#6339)",
     "#class"   : pixiv.PixivWorkExtractor,


### PR DESCRIPTION
Ugoira with `limit_sanity_level` will fail to download properly, for both `ugoira: original` and if just downloading the zip. For such works, it is necessary to use an AJAX request for both the illust metadata (`https://www.pixiv.net/ajax/illust/<illust_id>`), to get the general illust metadata that is missing from the mobile API `/v1/user/illusts` response, and the ugoira metadata (`https://www.pixiv.net/ajax/illust/<illust_id>/ugoira_meta`) that also includes the frames, zip url etc. 

An example of this happening is for some reason this (very mildly NSFW): https://www.pixiv.net/en/artworks/103841583. It results in just the first frame being downloaded, since it's listed as the "original" image in the AJAX illust metadata and the current sanity level handling will not treat it as an ugoira. If you attempt to force gallery-dl to do so and get the ugoira metadata via the mobile API, you get `NotFoundError - Requested resource (gallery/image) could not be found`.