### PR TITLE
[pixiv] fix novel embeds with AJAX request

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -926,8 +926,9 @@ class PixivNovelExtractor(PixivExtractor):
                 if desktop:
                     novel_id = str(novel["id"])
                     data = self._request_ajax("/novel/" + novel_id)
+                    images = (data["textEmbeddedImages"]).values()
 
-                    for image in (data["textEmbeddedImages"]).values():
+                    for image in images:
                         url = image.pop("urls")["original"]
                         novel.update(image)
                         novel["date_url"] = self._date_from_url(url)

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -866,16 +866,6 @@ class PixivNovelExtractor(PixivExtractor):
         embeds = self.config("embeds")
         covers = self.config("covers")
 
-        if embeds:
-            headers = {
-                "User-Agent"    : "Mozilla/5.0",
-                "App-OS"        : None,
-                "App-OS-Version": None,
-                "App-Version"   : None,
-                "Referer"       : self.root + "/",
-                "Authorization" : None,
-            }
-
         novels = self.novels()
         if self.max_posts:
             novels = itertools.islice(novels, self.max_posts)

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -929,7 +929,9 @@ class PixivNovelExtractor(PixivExtractor):
                         data = self._request_ajax("/novel/" + novel_id)
                         images = (data["textEmbeddedImages"]).values()
                     except Exception:
-                        self.log.error("Failed to get embedded novel images:", novel_id)
+                        self.log.error(
+                            "Failed to get embedded novel images:",
+                            novel_id)
                         images = ()
 
                     for image in images:

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -934,19 +934,10 @@ class PixivNovelExtractor(PixivExtractor):
                         illusts[marker[11:].partition("-")[0]] = None
 
                 if desktop:
-                    try:
-                        novel_id = str(novel["id"])
-                        url = "{}/novel/show.php?id={}".format(
-                            self.root, novel_id)
-                        data = util.json_loads(text.extr(
-                            self.request(url, headers=headers).text,
-                            "id=\"meta-preload-data\" content='", "'"))
-                        images = (data["novel"][novel_id]
-                                  ["textEmbeddedImages"]).values()
-                    except Exception:
-                        images = ()
+                    novel_id = str(novel["id"])
+                    data = self._request_ajax("/novel/" + novel_id)
 
-                    for image in images:
+                    for image in (data["textEmbeddedImages"]).values():
                         url = image.pop("urls")["original"]
                         novel.update(image)
                         novel["date_url"] = self._date_from_url(url)

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -928,10 +928,10 @@ class PixivNovelExtractor(PixivExtractor):
                         novel_id = str(novel["id"])
                         data = self._request_ajax("/novel/" + novel_id)
                         images = (data["textEmbeddedImages"]).values()
-                    except Exception:
-                        self.log.error(
-                            "Failed to get embedded novel images: %s",
-                            novel_id)
+                    except Exception as exc:
+                        self.log.warning(
+                            "%s: Failed to get embedded novel images (%s: %s)",
+                            novel_id, exc.__class__.__name__, exc)
                         images = ()
 
                     for image in images:

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -924,9 +924,13 @@ class PixivNovelExtractor(PixivExtractor):
                         illusts[marker[11:].partition("-")[0]] = None
 
                 if desktop:
-                    novel_id = str(novel["id"])
-                    data = self._request_ajax("/novel/" + novel_id)
-                    images = (data["textEmbeddedImages"]).values()
+                    try:
+                        novel_id = str(novel["id"])
+                        data = self._request_ajax("/novel/" + novel_id)
+                        images = (data["textEmbeddedImages"]).values()
+                    except Exception:
+                        self.log.error("Failed to get embedded novel images:", novel_id)
+                        images = ()
 
                     for image in images:
                         url = image.pop("urls")["original"]

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -930,7 +930,7 @@ class PixivNovelExtractor(PixivExtractor):
                         images = (data["textEmbeddedImages"]).values()
                     except Exception:
                         self.log.error(
-                            "Failed to get embedded novel images:",
+                            "Failed to get embedded novel images: %s",
                             novel_id)
                         images = ()
 

--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -925,13 +925,12 @@ class PixivNovelExtractor(PixivExtractor):
 
                 if desktop:
                     try:
-                        novel_id = str(novel["id"])
-                        data = self._request_ajax("/novel/" + novel_id)
-                        images = (data["textEmbeddedImages"]).values()
+                        body = self._request_ajax("/novel/" + str(novel["id"]))
+                        images = body["textEmbeddedImages"].values()
                     except Exception as exc:
                         self.log.warning(
                             "%s: Failed to get embedded novel images (%s: %s)",
-                            novel_id, exc.__class__.__name__, exc)
+                            novel["id"], exc.__class__.__name__, exc)
                         images = ()
 
                     for image in images:


### PR DESCRIPTION
Fixing the root cause of a recently closed issue https://github.com/mikf/gallery-dl/issues/7422. It seems that extraction of all novel embeds was broken after a recent site change with the `meta-preload-data` no longer being present in html (which also broke pixivutil). This PR switches the php request with html parsing for an AJAX call that contains the same information.