### PR TITLE
[Weasyl] Accept URLs of format /view/12345

### DIFF
--- a/gallery_dl/extractor/weasyl.py
+++ b/gallery_dl/extractor/weasyl.py
@@ -72,7 +72,7 @@ class WeasylExtractor(Extractor):
 
 class WeasylSubmissionExtractor(WeasylExtractor):
     subcategory = "submission"
-    pattern = BASE_PATTERN + r"(?:~[\w~-]+/submissions|submission)/(\d+)"
+    pattern = BASE_PATTERN + r"(?:~[\w~-]+/submissions|submission|view)/(\d+)"
     example = "https://www.weasyl.com/~USER/submissions/12345/TITLE"
 
     def __init__(self, match):


### PR DESCRIPTION
This trivial MR adds support of "view" URLs for Weasyl.

Example of link: https://weasyl.com/view/2488019

(It's not mentionned in the API documentation, but I've seen people sharing links in this format, and as it gets refused by gallery-dl, I thought it would be nice to support it (AKA simply modifying the regex).

I didn't find any specific guidelines for contributions, sorry if tihs one isn't following them!