### PR TITLE
[Szurubooru] Use username/token config per instance instead of global ids

### DIFF
--- a/gallery_dl/extractor/szurubooru.py
+++ b/gallery_dl/extractor/szurubooru.py
@@ -26,9 +26,9 @@ class SzurubooruExtractor(booru.BooruExtractor):
             "Content-Type": "application/json",
         }
 
-        username = self.config("username")
+        username = self.config_instance("username")
         if username:
-            token = self.config("token")
+            token = self.config_instance("token")
             if token:
                 value = username + ":" + token
                 self.headers["Authorization"] = "Token " + \


### PR DESCRIPTION
This MR simply allows using tokens/usernames "per instance" instead of only using ids defined for all instances of this extractor.