### PR TITLE
[VSCO] Fix JSON returned by VSCO

### DIFF
--- a/gallery_dl/extractor/vsco.py
+++ b/gallery_dl/extractor/vsco.py
@@ -79,7 +79,7 @@ class VscoExtractor(Extractor):
     def _extract_preload_state(self, url):
         page = self.request(url, notfound=self.subcategory).text
         return util.json_loads(text.extr(page, "__PRELOADED_STATE__ = ", "<")
-                               .replace("undefined", "null"))
+                               .replace('":undefined', '":null'))
 
     def _pagination(self, url, params, token, key, extra=None):
         headers = {


### PR DESCRIPTION
The JSON returned contains multiple `undefined` values that aren't valid JSON, changing these values to `null` fixes the issue.

This is a generalization of #6891