### PR TITLE
Enable pool metadata on Inkbunny extractor

### DIFF
--- a/gallery_dl/extractor/inkbunny.py
+++ b/gallery_dl/extractor/inkbunny.py
@@ -304,6 +304,7 @@ class InkbunnyAPI():
         params = {
             "submission_ids": ",".join(ids),
             "show_description": "yes",
+            "show_pools": "yes",
         }
 
         submissions = [None] * len(ids)


### PR DESCRIPTION
This pull request allows the Inkbunny extractor to fetch metadata for `pools[]`. Currently, the extractor produces the `pools` property but always sets it to an empty array. This is because the API requires passing `show_pools: yes` in order to retrieve pool information.

I've flip-flopped on making this a new extractor option, but I decided not to since I don't think it will bloat the metadata file that much relative to its current size. Please let me know if I should change that.

I didn't notice any contribution guidelines so I hope I didn't miss anything.