### PR TITLE
[facebook] add retries to profile page request

### DIFF
--- a/gallery_dl/extractor/facebook.py
+++ b/gallery_dl/extractor/facebook.py
@@ -413,9 +413,13 @@ class FacebookProfileExtractor(FacebookExtractor):
         profile_photos_url = (
             self.root + "/" + self.groups[0] + "/photos_by"
         )
-        profile_photos_page = self.request(profile_photos_url).text
 
-        set_id = self.get_profile_photos_set_id(profile_photos_page)
+        for _ in range(self.fallback_retries + 1):
+            profile_photos_page = self.request(profile_photos_url).text
+            set_id = self.get_profile_photos_set_id(profile_photos_page)
+            if set_id:
+                break
+            self.log.debug("Failed to find profile photos set ID, retrying...")
 
         if set_id:
             set_url = f"{self.root}/media/set/?set={set_id}"


### PR DESCRIPTION
Fixes #7834 and is probably also what's behind the issue at #7725 
I can see no discernible error message on the webpages that have not yet fully loaded, so I assume this is an inconsistency on Facebook's end. This doesn't mean there can't be a better way to fix this, this is just the bare minimum.