### PR TITLE
[snap] fix deprecated CRAFT_ARCH_TRIPLET usage

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,4 +100,4 @@ apps:
       LC_ALL: C.UTF-8
 
       # Satisfy FFmpeg's libpulsecommon dependency
-      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio


### PR DESCRIPTION
This fixes the following warning during the pull
phase:

```
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
```