### PR TITLE
[leakgallery.com] add support

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -548,6 +548,12 @@ Consider all listed sites to potentially be NSFW.
     <td></td>
 </tr>
 <tr>
+    <td>Leakgallery</td>
+    <td>https://leakgallery.com</td>
+    <td>Mostlikeds, Posts, Trendings, User Profiles</td>
+    <td></td>
+</tr>
+<tr>
     <td>Lensdump</td>
     <td>https://lensdump.com/</td>
     <td>Albums, individual Images</td>

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -99,6 +99,7 @@ modules = [
     "kemono",
     "khinsider",
     "komikcast",
+    "leakgallery",
     "lensdump",
     "lexica",
     "lightroom",

--- a/gallery_dl/extractor/leakgallery.py
+++ b/gallery_dl/extractor/leakgallery.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://leakgallery.com"""
+
+import re
+from .common import Extractor, Message
+from .. import text
+
+BASE_PATTERN = r"(?:https?://)?(?:www\.)?leakgallery\.com"
+
+
+class LeakGalleryPostExtractor(Extractor):
+    """Extractor for individual posts on leakgallery.com"""
+    category = "leakgallery"
+    subcategory = "post"
+    pattern = BASE_PATTERN + r"/([^/?#]+)/(\d+)"
+    example = "https://leakgallery.com/model/id"
+    directory_fmt = ("{category}", "{creator}")
+    filename_fmt = "{id}_{filename}.{extension}"
+    archive_fmt = "{id}"
+
+    def __init__(self, match):
+        Extractor.__init__(self, match)
+        self.creator, self.id = match.groups()
+        self.url = f"https://leakgallery.com/{self.creator}/{self.id}"
+
+    def items(self):
+        page = self.request(self.url).text
+        video_urls = re.findall(
+            r'https://cdn\.leakgallery\.com/content\d+/compressed_watermark_[^"]+\.mp4', page)
+        image_urls = re.findall(
+            r'https://cdn\.leakgallery\.com/content\d+/watermark_[^"]+\.jpe?g', page)
+
+        for url in set(video_urls + image_urls):
+            data = {
+                "creator": self.creator,
+                "id": self.id,
+                "url": url,
+            }
+            text.nameext_from_url(url, data)
+            if "extension" not in data or not data["extension"]:
+                data["extension"] = url.split(".")[-1]
+            yield Message.Directory, data
+            yield Message.Url, url, data
+
+
+class LeakGalleryUserExtractor(Extractor):
+    """Extractor for all posts from a leakgallery user"""
+    category = "leakgallery"
+    subcategory = "user"
+    pattern = BASE_PATTERN + r"/([^/?#]+)(?:/(Photos|Videos))?(?:/(MostRecent|MostViewed|MostLiked))?/?$"
+    example = "https://leakgallery.com/model/Photos/MostViewed"
+    directory_fmt = ("{category}", "{creator}")
+    filename_fmt = "{id}_{filename}.{extension}"
+    archive_fmt = "{id}"
+
+    def __init__(self, match):
+        Extractor.__init__(self, match)
+        self.creator = match.group(1)
+        type_map = {
+            None: "All",
+            "Photos": "Photos",
+            "Videos": "Videos"
+        }
+        sort_map = {
+            None: "MostRecent",
+            "MostRecent": "MostRecent",
+            "MostViewed": "MostViewed",
+            "MostLiked": "MostLiked"
+        }
+        self.type = type_map.get(match.group(2))
+        self.sort = sort_map.get(match.group(3))
+
+    def items(self):
+        base = f"https://api.leakgallery.com/profile/{self.creator}/"
+        params = {
+            "type": self.type,
+            "sort": self.sort
+        }
+
+        page = 1
+        while True:
+            response = self.request(base + str(page), params=params).json()
+            medias = response.get("medias")
+            if not isinstance(medias, list) or not medias:
+                return
+
+            for media in medias:
+                cdn_url = "https://cdn.leakgallery.com/" + media["file_path"]
+                data = {
+                    "id": media["id"],
+                    "creator": self.creator,
+                    "category": self.category,
+                    "url": cdn_url,
+                    "_extractor": self,
+                }
+                text.nameext_from_url(cdn_url, data)
+                yield Message.Directory, data
+                yield Message.Url, cdn_url, data
+            page += 1

--- a/gallery_dl/extractor/leakgallery.py
+++ b/gallery_dl/extractor/leakgallery.py
@@ -6,99 +6,143 @@
 
 """Extractors for https://leakgallery.com"""
 
-import re
 from .common import Extractor, Message
-from .. import text
+from .. import text, exception
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?leakgallery\.com"
 
 
-class LeakGalleryPostExtractor(Extractor):
-    """Extractor for individual posts on leakgallery.com"""
+class LeakGalleryExtractorBase(Extractor):
     category = "leakgallery"
-    subcategory = "post"
-    pattern = BASE_PATTERN + r"/([^/?#]+)/(\d+)"
-    example = "https://leakgallery.com/model/id"
     directory_fmt = ("{category}", "{creator}")
     filename_fmt = "{id}_{filename}.{extension}"
-    archive_fmt = "{id}"
+    archive_fmt = "{creator}_{id}"
 
-    def __init__(self, match):
-        Extractor.__init__(self, match)
-        self.creator, self.id = match.groups()
-        self.url = f"https://leakgallery.com/{self.creator}/{self.id}"
-
-    def items(self):
-        page = self.request(self.url).text
-        video_urls = re.findall(
-            r'https://cdn\.leakgallery\.com/content\d+/compressed_watermark_[^"]+\.mp4', page)
-        image_urls = re.findall(
-            r'https://cdn\.leakgallery\.com/content\d+/watermark_[^"]+\.jpe?g', page)
-
-        for url in set(video_urls + image_urls):
+    def _yield_media_items(self, medias, creator=None):
+        seen = set()
+        for media in medias:
+            cdn_url = "https://cdn.leakgallery.com/" + media["file_path"]
+            if cdn_url in seen:
+                continue
+            seen.add(cdn_url)
+            media_creator = media.get("profile", {}).get("username") or creator or "unknown"
             data = {
-                "creator": self.creator,
-                "id": self.id,
-                "url": url,
+                "id": media["id"],
+                "creator": media_creator,
+                "category": self.category,
+                "url": cdn_url,
+                "_extractor": self,
             }
-            text.nameext_from_url(url, data)
-            if "extension" not in data or not data["extension"]:
-                data["extension"] = url.split(".")[-1]
+            text.nameext_from_url(cdn_url, data)
             yield Message.Directory, data
-            yield Message.Url, url, data
+            yield Message.Url, cdn_url, data
 
 
-class LeakGalleryUserExtractor(Extractor):
-    """Extractor for all posts from a leakgallery user"""
-    category = "leakgallery"
+class LeakGalleryUserExtractor(LeakGalleryExtractorBase):
+    """Extractor for profile posts on leakgallery.com"""
     subcategory = "user"
-    pattern = BASE_PATTERN + r"/([^/?#]+)(?:/(Photos|Videos))?(?:/(MostRecent|MostViewed|MostLiked))?/?$"
-    example = "https://leakgallery.com/model/Photos/MostViewed"
-    directory_fmt = ("{category}", "{creator}")
-    filename_fmt = "{id}_{filename}.{extension}"
-    archive_fmt = "{id}"
-
-    def __init__(self, match):
-        Extractor.__init__(self, match)
-        self.creator = match.group(1)
-        type_map = {
-            None: "All",
-            "Photos": "Photos",
-            "Videos": "Videos"
-        }
-        sort_map = {
-            None: "MostRecent",
-            "MostRecent": "MostRecent",
-            "MostViewed": "MostViewed",
-            "MostLiked": "MostLiked"
-        }
-        self.type = type_map.get(match.group(2))
-        self.sort = sort_map.get(match.group(3))
+    pattern = BASE_PATTERN + r"/(?!trending-medias|most-liked|random/medias)([^/?#]+)(?:/(Photos|Videos|All))?(?:/(MostRecent|MostViewed|MostLiked))?/?$"
+    example = "https://leakgallery.com/creator"
 
     def items(self):
-        base = f"https://api.leakgallery.com/profile/{self.creator}/"
-        params = {
-            "type": self.type,
-            "sort": self.sort
-        }
+        creator = self.groups[0]
+        mtype = self.groups[1] or "All"
+        msort = self.groups[2] or "MostRecent"
+
+        base = f"https://api.leakgallery.com/profile/{creator}/"
+        params = {"type": mtype, "sort": msort}
 
         page = 1
         while True:
-            response = self.request(base + str(page), params=params).json()
-            medias = response.get("medias")
-            if not isinstance(medias, list) or not medias:
+            try:
+                response = self.request(base + str(page), params=params).json()
+                medias = response.get("medias")
+                if not isinstance(medias, list) or not medias:
+                    return
+                yield from self._yield_media_items(medias, creator=creator)
+                page += 1
+            except Exception as e:
+                self.log("error", f"Failed to retrieve page {page}: {e}")
                 return
 
-            for media in medias:
-                cdn_url = "https://cdn.leakgallery.com/" + media["file_path"]
+
+class LeakGalleryTrendingExtractor(LeakGalleryExtractorBase):
+    """Extractor for trending posts on leakgallery.com"""
+    subcategory = "trending"
+    pattern = BASE_PATTERN + r"/trending-medias(?:/([A-Za-z0-9\-]+))?"
+    example = "https://leakgallery.com/trending-medias/Week"
+
+    def items(self):
+        period = self.groups[0] or "Last-Hour"
+        page = 1
+        while True:
+            try:
+                url = f"https://api.leakgallery.com/popular/media/{period}/{page}"
+                response = self.request(url).json()
+                if not response:
+                    return
+                yield from self._yield_media_items(response)
+                page += 1
+            except Exception as e:
+                self.log("error", f"Failed to retrieve trending page {page}: {e}")
+                return
+
+
+class LeakGalleryMostLikedExtractor(LeakGalleryExtractorBase):
+    """Extractor for most liked posts on leakgallery.com"""
+    subcategory = "mostliked"
+    pattern = BASE_PATTERN + r"/most-liked"
+    example = "https://leakgallery.com/most-liked"
+
+    def items(self):
+        page = 1
+        while True:
+            try:
+                url = f"https://api.leakgallery.com/most-liked/{page}"
+                response = self.request(url).json()
+                if not response:
+                    return
+                yield from self._yield_media_items(response)
+                page += 1
+            except Exception as e:
+                self.log("error", f"Failed to retrieve most-liked page {page}: {e}")
+                return
+
+
+class LeakGalleryPostExtractor(LeakGalleryExtractorBase):
+    """Extractor for individual posts on leakgallery.com"""
+    subcategory = "post"
+    pattern = BASE_PATTERN + r"/([^/?#]+)/([0-9]+)"
+    example = "https://leakgallery.com/creator/post_id"
+
+    def items(self):
+        creator, post_id = self.groups
+        self.url = f"https://leakgallery.com/{creator}/{post_id}"
+        try:
+            page = self.request(self.url).text
+            video_urls = text.re(
+                r'https://cdn\.leakgallery\.com/content[^/]*/(?:compressed_)?watermark_[^\"]+\.(?:mp4|mov|m4a|webm)'
+            ).findall(page)
+            image_urls = text.re(
+                r'https://cdn\.leakgallery\.com/content[^/]*/watermark_[^\"]+\.(?:jpe?g|png)'
+            ).findall(page)
+
+            seen = set()
+            for url in video_urls + image_urls:
+                if url in seen:
+                    continue
+                seen.add(url)
                 data = {
-                    "id": media["id"],
-                    "creator": self.creator,
+                    "id": post_id,
+                    "creator": creator,
                     "category": self.category,
-                    "url": cdn_url,
-                    "_extractor": self,
+                    "url": url,
                 }
-                text.nameext_from_url(cdn_url, data)
+                text.nameext_from_url(url, data)
                 yield Message.Directory, data
-                yield Message.Url, cdn_url, data
-            page += 1
+                yield Message.Url, url, data
+
+            if not seen:
+                self.log("info", f"No downloadable media found for {self.url}")
+        except Exception as e:
+            self.log("error", f"Failed to extract post page: {e}")

--- a/test/results/leakgallery.py
+++ b/test/results/leakgallery.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from gallery_dl.extractor import leakgallery
+from gallery_dl import exception
+
+__tests__ = (
+    {
+        "#url": "https://leakgallery.com/sophieraiin/12240",
+        "#category": ("", "leakgallery", "post"),
+        "#class": leakgallery.LeakGalleryPostExtractor,
+        "id": 12240,
+        "creator": "sophieraiin",
+    },
+    {
+        "#url": "https://leakgallery.com/sophieraiin",
+        "#category": ("", "leakgallery", "user"),
+        "#class": leakgallery.LeakGalleryUserExtractor,
+    },
+    {
+        "#url": "https://leakgallery.com/trending-medias/Week",
+        "#category": ("", "leakgallery", "trending"),
+        "#class": leakgallery.LeakGalleryTrendingExtractor,
+    },
+    {
+        "#url": "https://leakgallery.com/most-liked",
+        "#category": ("", "leakgallery", "mostliked"),
+        "#class": leakgallery.LeakGalleryMostLikedExtractor,
+    },
+)


### PR DESCRIPTION
This adds support for leakgallery.com, including:
- User pages with pagination via API (AJAX)
- Individual post pages (photo/video)
- Trending media pages (with time filters)
- Most-liked media section

Also includes:
- Entry in extractor/init.py
- Updated docs/supportedsites.md
- Basic result tests in test/results/leakgallery.py