### PR TITLE
Use False as default instead of None to avoid TypeError

### DIFF
--- a/gallery_dl/postprocessor/exec.py
+++ b/gallery_dl/postprocessor/exec.py
@@ -35,7 +35,7 @@ class ExecPP(PostProcessor):
             if options.get("async", False):
                 self._exec = self._popen
 
-        self.session = None
+        self.session = False
         self.creationflags = 0
         if options.get("session"):
             if util.WINDOWS:

--- a/test/test_postprocessor.py
+++ b/test/test_postprocessor.py
@@ -211,7 +211,7 @@ class ExecTest(BasePostprocessorTest):
                 self.pathfmt.filename),
             shell=True,
             creationflags=0,
-            start_new_session=None,
+            start_new_session=False,
         )
         i.wait.assert_called_once_with()
 
@@ -235,7 +235,7 @@ class ExecTest(BasePostprocessorTest):
             ],
             shell=False,
             creationflags=0,
-            start_new_session=None,
+            start_new_session=False,
         )
 
     def test_command_many(self):
@@ -260,7 +260,7 @@ class ExecTest(BasePostprocessorTest):
                     self.pathfmt.filename),
                 shell=True,
                 creationflags=0,
-                start_new_session=None,
+                start_new_session=False,
             ),
             call(
                 [
@@ -270,7 +270,7 @@ class ExecTest(BasePostprocessorTest):
                 ],
                 shell=False,
                 creationflags=0,
-                start_new_session=None,
+                start_new_session=False,
             ),
         ])
 


### PR DESCRIPTION
The session variable in the exec postprocessor defaults to `None` which results in the following exception:
```
Traceback (most recent call last):
  File "[REDACTED]/gallery-dl/gallery_dl/job.py", line 153, in run
    self.dispatch(msg)
  File "[REDACTED]/gallery-dl/gallery_dl/job.py", line 204, in dispatch
    self.handle_url(url, kwdict)
  File "[REDACTED]/gallery-dl/gallery_dl/job.py", line 387, in handle_url
    callback(pathfmt)
  File "[REDACTED]/gallery-dl/gallery_dl/postprocessor/exec.py", line 75, in exec_list
    retcode = self._exec(args, False)
  File "[REDACTED]/gallery-dl/gallery_dl/postprocessor/exec.py", line 113, in _exec
    if retcode := self._popen(args, shell).wait():
  File "[REDACTED]/gallery-dl/gallery_dl/postprocessor/exec.py", line 120, in _popen
    return util.Popen(
  File "[REDACTED]/.pyenv/versions/3.10.12/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "[REDACTED]/.pyenv/versions/3.10.12/lib/python3.10/subprocess.py", line 1796, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: 'NoneType' object cannot be interpreted as an integer
```

According to the documentation `start_new_session` is a boolean. Changing the default to `False` fixes the error.
https://docs.python.org/3/library/subprocess.html#popen-constructor