### PR TITLE
[hentai-foundry] Html description option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2969,6 +2969,19 @@ Description
     Recursively download files from subfolders.
 
 
+extractor.hentaifoundry.descriptions
+----------------------------------
+Type
+    ``string``
+Default
+    ``"text"``
+Description
+    Controls the format of ``description`` metadata fields.
+
+    * ``"text"``: Plain text with HTML tags removed
+    * ``"html"``: Raw HTML content
+
+
 extractor.hentaifoundry.include
 -------------------------------
 Type

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -364,6 +364,7 @@
         },
         "hentaifoundry":
         {
+            "descriptions": "text",
             "include": ["pictures"]
         },
         "hitomi":

--- a/gallery_dl/extractor/hentaifoundry.py
+++ b/gallery_dl/extractor/hentaifoundry.py
@@ -83,7 +83,7 @@ class HentaifoundryExtractor(Extractor):
                 '<div class="boxbody"', '<div class="boxfooter"'),
             "_description": extr(
                 "<div class='picDescript'>", '</section>')
-                .replace("\r\n", "\n"),
+            .replace("\r\n", "\n"),
             "ratings"    : [text.unescape(r) for r in text.extract_iter(extr(
                 "class='ratings_box'", "</div>"), "title='", "'")],
             "date"       : text.parse_datetime(extr("datetime='", "'")),
@@ -112,8 +112,8 @@ class HentaifoundryExtractor(Extractor):
         return text.nameext_from_url(data["src"], data)
 
     def _process_html_description(self, description: str):
-        pos1 = description.rfind('</div') # picDescript
-        pos2 = description.rfind('</div', None, pos1) # boxBody
+        pos1 = description.rfind('</div')  # picDescript
+        pos2 = description.rfind('</div', None, pos1)  # boxBody
         return str.strip(description[0:pos2])
 
     def _process_description(self, description):


### PR DESCRIPTION
It makes sense to have an option in an html-based extractor to preserve significant html.

+ Implementation immitates the very similar feature of the furaffinity extractor.
+ This only affects descriptions of image posts; stories already return html.
+ Example post with anchor tags in description: <https://www.hentai-foundry.com/pictures/user/TDL/1163076/The-Movement---Shineseal-Oil>