### PR TITLE
[everia] Fix image extraction

### DIFF
--- a/gallery_dl/extractor/everia.py
+++ b/gallery_dl/extractor/everia.py
@@ -52,7 +52,7 @@ class EveriaPostExtractor(EveriaExtractor):
         url = self.root + self.groups[0] + "/"
         page = self.request(url).text
         content = text.extr(page, 'itemprop="text">', "<h3")
-        urls = util.re(r'img.*?src="([^"]+)').findall(content)
+        urls = util.re(r'img.*?lazy-src="([^"]+)').findall(content)
 
         data = {
             "title": text.unescape(


### PR DESCRIPTION
They apparently decided to implement lazy loading in javascript instead of using `loading="lazy"`, so `src` is now a placeholder and the real URL is in `data-lazy-src`.