### PR TITLE
fix(imagebam): update cookies to bypass guard page

### DIFF
--- a/gallery_dl/extractor/imagebam.py
+++ b/gallery_dl/extractor/imagebam.py
@@ -23,6 +23,7 @@ class ImagebamExtractor(Extractor):
 
     def _init(self):
         self.cookies.set("nsfw_inter", "1", domain="www.imagebam.com")
+        self.cookies.set("sfw_inter", "1", domain="www.imagebam.com")
 
     def _parse_image_page(self, path):
         page = self.request(self.root + path).text


### PR DESCRIPTION
Hello,

As of a few days ago, it seems the imagebam extractor is broken.

On any given URL, I'd get this output in verbose mode:
```
[gallery-dl][debug] Starting DownloadJob for 'https://www.imagebam.com/image/3e141447416527'
[imagebam][debug] Using ImagebamImageExtractor for 'https://www.imagebam.com/image/3e141447416527'
[urllib3.connectionpool][debug] https://www.imagebam.com:443 "GET /image/3e141447416527 HTTP/1.1" 200 None
[imagebam][error] An unexpected error occurred: TypeError - argument of type 'NoneType' is not iterable. Please run gallery-dl again with the --verbose flag, copy its output and report this issue on https://github.com/mikf/gallery-dl/issues .
[imagebam][debug]
Traceback (most recent call last):
  File "/home/bvergnaud/.local/share/uv/tools/gallery-dl/lib/python3.12/site-packages/gallery_dl/job.py", line 152, in run
    for msg in extractor:
               ^^^^^^^^^
  File "/home/bvergnaud/.local/share/uv/tools/gallery-dl/lib/python3.12/site-packages/gallery_dl/extractor/imagebam.py", line 97, in items
    image = self._parse_image_page(path)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bvergnaud/.local/share/uv/tools/gallery-dl/lib/python3.12/site-packages/gallery_dl/extractor/imagebam.py", line 30, in _parse_image_page
    filename = text.unescape(text.extract(page, 'alt="', '"', pos)[0])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bvergnaud/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/html/__init__.py", line 130, in unescape
    if '&' not in s:
       ^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

Doing some basic print-debugging, I noticed that the page text reflected the "Continue to your image" protection page that they sometimes show, instead of the actual page with the image.

I ended up guessing that the `nsfw_inter` cookies that's set by the extractor was meant to bypass that page and sure enough in my browser session it had a different name. Adding the new cookie fixes the issue I had and the extractor works normally again.

Cheers.