### PR TITLE
Adds a new `DanbooruRandomExtractor` to support downloading random posts.

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -1252,25 +1252,25 @@ Consider all listed sites to potentially be NSFW.
 <tr id="danbooru" title="danbooru">
     <td>Danbooru</td>
     <td>https://danbooru.donmai.us/</td>
-    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Tag Searches</td>
+    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Random Posts, Tag Searches</td>
     <td>Supported</td>
 </tr>
 <tr id="atfbooru" title="atfbooru">
     <td>ATFBooru</td>
     <td>https://booru.allthefallen.moe/</td>
-    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Tag Searches</td>
+    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Random Posts, Tag Searches</td>
     <td>Supported</td>
 </tr>
 <tr id="aibooru" title="aibooru">
     <td>AIBooru</td>
     <td>https://aibooru.online/</td>
-    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Tag Searches</td>
+    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Random Posts, Tag Searches</td>
     <td>Supported</td>
 </tr>
 <tr id="booruvar" title="booruvar">
     <td>Booruvar</td>
     <td>https://booru.borvar.art/</td>
-    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Tag Searches</td>
+    <td>Artists, Artist Searches, Favorite Groups, Pools, Popular Images, Posts, Random Posts, Tag Searches</td>
     <td>Supported</td>
 </tr>
 

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -278,6 +278,20 @@ class DanbooruTagExtractor(DanbooruExtractor):
         return self._pagination("/posts.json", {"tags": self.tags}, prefix)
 
 
+class DanbooruRandomExtractor(DanbooruTagExtractor):
+    """Extractor for a random danbooru post from a tag search"""
+    subcategory = "random"
+    pattern = BASE_PATTERN + r"/posts/random\?(?:[^&#]*&)*tags=([^&#]*)"
+    example = "https://danbooru.donmai.us/posts/random?tags=TAG"
+
+    def posts(self):
+        posts = self.request_json(
+            self.root + "/posts/random.json", params={"tags": self.tags})
+        if isinstance(posts, dict):
+            return (posts,)
+        return posts
+
+
 class DanbooruPoolExtractor(DanbooruExtractor):
     """Extractor for Danbooru pools"""
     subcategory = "pool"

--- a/gallery_dl/extractor/danbooru.py
+++ b/gallery_dl/extractor/danbooru.py
@@ -279,17 +279,20 @@ class DanbooruTagExtractor(DanbooruExtractor):
 
 
 class DanbooruRandomExtractor(DanbooruTagExtractor):
-    """Extractor for a random danbooru post from a tag search"""
+    """Extractor for a random danbooru post"""
     subcategory = "random"
-    pattern = BASE_PATTERN + r"/posts/random\?(?:[^&#]*&)*tags=([^&#]*)"
+    pattern = BASE_PATTERN + r"/posts/random(?:\?(?:[^&#]*&)*tags=([^&#]*))?"
     example = "https://danbooru.donmai.us/posts/random?tags=TAG"
 
+    def metadata(self):
+        tags = self.groups[-1] or ""
+        self.tags = text.unquote(tags.replace("+", " "))
+        return {"search_tags": self.tags}
+
     def posts(self):
-        posts = self.request_json(
-            self.root + "/posts/random.json", params={"tags": self.tags})
-        if isinstance(posts, dict):
-            return (posts,)
-        return posts
+        posts = self.request_json(self.root + "/posts/random.json",
+                                  params={"tags": self.tags or None})
+        return (posts,) if isinstance(posts, dict) else posts
 
 
 class DanbooruPoolExtractor(DanbooruExtractor):

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -264,6 +264,7 @@ SUBCATEGORY_MAP = {
     },
     "Danbooru": {
         "favgroup": "Favorite Groups",
+        "random"  : "Random Posts",
     },
     "desktopography": {
         "site": "",

--- a/test/results/aibooru.py
+++ b/test/results/aibooru.py
@@ -80,4 +80,24 @@ __tests__ = (
     "#class"   : danbooru.DanbooruPopularExtractor,
 },
 
+{
+    "#url"     : "https://aibooru.online/posts/random?tags=center_frills&z=1",
+    "#category": ("Danbooru", "aibooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+    "#pattern" : "https://cdn.aibooru.download/original/.+",
+    "#count"   : 1,
+
+    "search_tags": "center_frills",
+},
+
+{
+    "#url"     : "https://aibooru.online/posts/random",
+    "#category": ("Danbooru", "aibooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+    "#pattern" : "https://cdn.aibooru.download/original/.+",
+    "#count"   : 1,
+
+    "search_tags": "",
+},
+
 )

--- a/test/results/atfbooru.py
+++ b/test/results/atfbooru.py
@@ -36,4 +36,16 @@ __tests__ = (
     "#class"   : danbooru.DanbooruPopularExtractor,
 },
 
+{
+    "#url"     : "https://booru.allthefallen.moe/posts/random?tags=yume_shokunin",
+    "#category": ("Danbooru", "atfbooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+},
+
+{
+    "#url"     : "https://booru.allthefallen.moe/posts/random",
+    "#category": ("Danbooru", "atfbooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+},
+
 )

--- a/test/results/booruvar.py
+++ b/test/results/booruvar.py
@@ -37,4 +37,16 @@ __tests__ = (
     "#class"   : danbooru.DanbooruPopularExtractor,
 },
 
+{
+    "#url"     : "https://booru.borvar.art/posts/random?tags=chibi&z=1",
+    "#category": ("Danbooru", "booruvar", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+},
+
+{
+    "#url"     : "https://booru.borvar.art/posts/random",
+    "#category": ("Danbooru", "booruvar", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+},
+
 )

--- a/test/results/danbooru.py
+++ b/test/results/danbooru.py
@@ -382,4 +382,24 @@ __tests__ = (
     "other_names": list,
 },
 
+{
+    "#url"     : "https://danbooru.donmai.us/posts/random?tags=bonocho",
+    "#category": ("Danbooru", "danbooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+    "#pattern" : "https://cdn.donmai.us/original/.+",
+    "#count"   : 1,
+
+    "search_tags": "bonocho",
+},
+
+{
+    "#url"     : "https://danbooru.donmai.us/posts/random",
+    "#category": ("Danbooru", "danbooru", "random"),
+    "#class"   : danbooru.DanbooruRandomExtractor,
+    "#pattern" : "https://cdn.donmai.us/original/.+",
+    "#count"   : 1,
+
+    "search_tags": "",
+},
+
 )


### PR DESCRIPTION
This pull request adds support for the /posts/random endpoint from Danbooru-like sites. This allows users to fetch a random post matching a specific set of tags with URLs such as
  https://danbooru.donmai.us/posts/random?tags=your_tag.

  Motivation:

  The /posts/random endpoint provides a more direct and efficient way to get a random post without needing to use order:random in a tag search. This is a convenient feature for users who want to quickly grab a random
  image with specific tags without extra steps.