### PR TITLE
[twitter] individual tweet extractor quoted_by_id_str incorrectly set

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -1026,11 +1026,12 @@ class TwitterTweetExtractor(TwitterExtractor):
             return
 
         while True:
+            parent_id = tweet["rest_id"]
             tweet_id = tweet["legacy"].get("quoted_status_id_str")
             if not tweet_id:
                 break
             tweet = self.api.tweet_result_by_rest_id(tweet_id)
-            tweet["legacy"]["quoted_by_id_str"] = tweet_id
+            tweet["legacy"]["quoted_by_id_str"] = parent_id
             yield tweet
 
     def _tweets_detail(self, tweet_id):


### PR DESCRIPTION
In the individual tweet extractor, `quoted_by_id_str` is currently being assigned to the ID of the quoted tweet itself, rather than the parent tweet (as shown [here](https://github.com/mikf/gallery-dl/blob/fd8d8dc98fcaac4a8953e7f2949592984a588fc4/gallery_dl/extractor/twitter.py#L2074)). This results in nested quotes being incorrectly mapped to themselves instead of their parent.