### PR TITLE
[wikimedia] add ability to download image revisions

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6548,6 +6548,20 @@ Description
     Download video files.
 
 
+extractor.wikimedia.image-revisions
+-----------------------------------
+Type
+    ``integer``
+Default
+    ``1``
+Description
+    Number of revisions to return for a single image.
+
+    The dafault value of 1 only returns the latest revision.
+
+    The value must be between 1 and 500.
+
+
 extractor.wikimedia.limit
 -------------------------
 Type

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6560,6 +6560,9 @@ Description
     The dafault value of 1 only returns the latest revision.
 
     The value must be between 1 and 500.
+Note
+    The API sometimes returns image revisions on article pages even when this option is
+    set to 1. However, setting it to a higher value may reduce the number of API requests.
 
 
 extractor.wikimedia.limit

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -1118,6 +1118,7 @@
         "wikimedia":
         {
             "sleep-request": "1.0-2.0",
+            "image-revisions": 1,
             "limit": 50,
             "subcategories": true
         },

--- a/gallery_dl/extractor/wikimedia.py
+++ b/gallery_dl/extractor/wikimedia.py
@@ -62,7 +62,7 @@ class WikimediaExtractor(BaseExtractor):
                 return url
         raise exception.AbortExtraction("Unable to find API endpoint")
 
-    def prepare_info(self, page):
+    def prepare_info(self, info):
         """Adjust the content of an image info object"""
 
     def prepare_image(self, image):

--- a/test/results/wikipedia.py
+++ b/test/results/wikipedia.py
@@ -45,16 +45,12 @@ __tests__ = (
 },
 
 {
-    "#url"     : "https://tl.wikipedia.org/wiki/Sitosol",
-    "#comment" : "revisions of an image in an article",
+    "#url"     : "https://en.wikipedia.org/wiki/Title",
+    "#comment" : "force download revisions of images in an article",
     "#category": ("wikimedia", "wikipedia", "article"),
     "#class"   : wikimedia.WikimediaArticleExtractor,
-    "#options" : {"image-revisions": 10},
-    "#count"   : 2,
-    "#pattern" : (
-        r"https://upload.wikimedia.org/wikipedia/commons/2/2e/Crowded_cytosol.png",
-        r"https://upload.wikimedia.org/wikipedia/commons/archive/2/2e/20080911161129%21Crowded_cytosol.png",
-    ),
+    "#options" : {"image-revisions": 5},
+    "#count"   : "> 8",
 },
 
 {

--- a/test/results/wikipedia.py
+++ b/test/results/wikipedia.py
@@ -51,6 +51,10 @@ __tests__ = (
     "#class"   : wikimedia.WikimediaArticleExtractor,
     "#options" : {"image-revisions": 5},
     "#count"   : "> 8",
+
+    "page" : "Title",
+    "count": {2, 5},
+    "num"  : range(1, 5),
 },
 
 {

--- a/test/results/wikipedia.py
+++ b/test/results/wikipedia.py
@@ -45,6 +45,19 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://tl.wikipedia.org/wiki/Sitosol",
+    "#comment" : "revisions of an image in an article",
+    "#category": ("wikimedia", "wikipedia", "article"),
+    "#class"   : wikimedia.WikimediaArticleExtractor,
+    "#options" : {"image-revisions": 10},
+    "#count"   : 2,
+    "#pattern" : (
+        r"https://upload.wikimedia.org/wikipedia/commons/2/2e/Crowded_cytosol.png",
+        r"https://upload.wikimedia.org/wikipedia/commons/archive/2/2e/20080911161129%21Crowded_cytosol.png",
+    ),
+},
+
+{
     "#url"     : "https://en.wikipedia.org/wiki/Category:Physics",
     "#category": ("wikimedia", "wikipedia", "category"),
     "#class"   : wikimedia.WikimediaArticleExtractor,


### PR DESCRIPTION
This only works if the number of revisions of a single image doesn't exceed 500, which I think should cover the vast majority of images on most wikis.