### PR TITLE
[wikimedia] fix name & extension of files without an extension

### DIFF
--- a/gallery_dl/extractor/wikimedia.py
+++ b/gallery_dl/extractor/wikimedia.py
@@ -74,9 +74,7 @@ class WikimediaExtractor(BaseExtractor):
             m["name"]: m["value"]
             for m in image["commonmetadata"] or ()}
 
-        filename = image["canonicaltitle"]
-        image["filename"], _, image["extension"] = \
-            filename.partition(":")[2].rpartition(".")
+        text.nameext_from_url(image["canonicaltitle"].partition(":")[2], image)
         image["date"] = text.parse_datetime(
             image["timestamp"], "%Y-%m-%dT%H:%M:%SZ")
 

--- a/test/results/fandom.py
+++ b/test/results/fandom.py
@@ -105,6 +105,19 @@ __tests__ = (
 },
 
 {
+    "#url"     : "https://youtube.fandom.com/wiki/File:(500)_Montage_-_Reason_2_Die_Awakening",
+    "#comment" : "file without extension",
+    "#category": ("wikimedia", "fandom-youtube", "file"),
+    "#class"   : wikimedia.WikimediaArticleExtractor,
+
+    "extension": "",
+    "filename" : "(500) Montage - Reason 2 Die Awakening",
+    "page"     : "File:(500)_Montage_-_Reason_2_Die_Awakening",
+    "sha1"     : "6819869792d85927d60cc0a0cdc9e33dbd446731",
+    "size"     : 81905,
+},
+
+{
     "#url"     : "https://youtube.fandom.com",
     "#category": ("wikimedia", "fandom-youtube", "wiki"),
     "#class"   : wikimedia.WikimediaWikiExtractor,


### PR DESCRIPTION
Before
```python
{
    "extension": "(500) Montage - Reason 2 Die Awakening",
    "filename" : "",
}
```
After
```python
{
    "extension": "",
    "filename" : "(500) Montage - Reason 2 Die Awakening",
}
```
This is especially common on Fandom where embedded YouTube videos are handled as extension-less image files.