### PR TITLE
added cr to list of cyberdrop TLDs

### DIFF
--- a/gallery_dl/extractor/cyberdrop.py
+++ b/gallery_dl/extractor/cyberdrop.py
@@ -10,7 +10,7 @@ from . import lolisafe
 from .common import Message
 from .. import text
 
-BASE_PATTERN = r"(?:https?://)?(?:www\.)?cyberdrop\.(?:me|to)"
+BASE_PATTERN = r"(?:https?://)?(?:www\.)?cyberdrop\.(?:me|to|cr)"
 
 
 class CyberdropAlbumExtractor(lolisafe.LolisafeAlbumExtractor):


### PR DESCRIPTION
cyberdrop is now using .cr for downloads. 

