### PR TITLE
[patreon] Include full metadata object with each url

### DIFF
--- a/gallery_dl/extractor/patreon.py
+++ b/gallery_dl/extractor/patreon.py
@@ -53,15 +53,14 @@ class PatreonExtractor(Extractor):
 
             post["num"] = 0
             hashes = set()
-            for kind, url_metadata, url, name in itertools.chain.from_iterable(
+            for kind, file, url, name in itertools.chain.from_iterable(
                     g(post) for g in generators):
                 fhash = self._filehash(url)
                 if fhash not in hashes or not fhash:
                     hashes.add(fhash)
                     post["hash"] = fhash
                     post["type"] = kind
-                    if url_metadata is not None:
-                        post["url_metadata"] = url_metadata
+                    post["file"] = file
                     post["num"] += 1
                     text.nameext_from_url(name, post)
                     if text.ext_from_url(url) == "m3u8":

--- a/test/results/patreon.py
+++ b/test/results/patreon.py
@@ -119,7 +119,7 @@ __tests__ = (
     "#class"   : patreon.PatreonPostExtractor,
     "#count"   : 4,
 
-    "url_metadata": dict,
+    "file": {dict, None},
 },
 
 {


### PR DESCRIPTION
Fixes #4286

This allows access to the appropriate object for each file that contains information from Patreon about width, height, filename, etc.

For example, using `--filter 'type == "image"' --print "\fF resolution: {url_metadata['metadata']['dimensions']['w']}x{url_metadata['metadata']['dimensions']['h']}\nfilename: {url_metadata['file_name']}\n\n"` allows the proper output for the request in #4286.

This is not the same as using `num - 1` to access this data, as that number will become useless when there are, for example, both images _and_ attachments present.