### PR TITLE
[scripts/init] Fix error running with default values

### DIFF
--- a/scripts/init.py
+++ b/scripts/init.py
@@ -317,7 +317,7 @@ def parse_args(args=None):
 
     parser.add_argument(
         "-s", "--subcategory",
-        dest="subcategories", metavar="SUBCaT", action="append")
+        dest="subcategories", metavar="SUBCaT", action="append", default=[])
     parser.add_argument(
         "-n", "--name",
         dest="site_name", metavar="TITLE")


### PR DESCRIPTION
Fixes:
```sh
python scripts/init.py newsite https://newsite.com
# [INFO] gallery_dl/extractor/newsite.py
# [ERROR] TypeError: 'NoneType' object is not iterable
# Traceback (most recent call last):
#   File "/gallery-dl/scripts/init.py", line 58, in init_extractor
#     fp.write(func(args))
#              ^^^^^^^^^^
#   File "/gallery-dl/scripts/init.py", line 88, in generate_module
#     {generate_extractors(args)}\
#      ^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/gallery-dl/scripts/init.py", line 108, in generate_extractors_basic
#     for subcat in args.subcategories:
# TypeError: 'NoneType' object is not iterable
# [INFO] gallery_dl/extractor/__init__.py
# [INFO] test/results/newsite.py
```