### PR TITLE
fix(bunkr): catch new maintenance video file during validation

### DIFF
--- a/gallery_dl/extractor/bunkr.py
+++ b/gallery_dl/extractor/bunkr.py
@@ -202,12 +202,8 @@ class BunkrAlbumExtractor(LolisafeAlbumExtractor):
         }
 
     def _validate(self, response):
-        if response.history and any(
-            [
-                response.url.endswith("/maint.mp4"),
-                response.url.endswith("/maintenance-vid.mp4"),
-            ]
-        ):
+        if response.history and response.url.endswith(
+                ("/maint.mp4", "/maintenance-vid.mp4")):
             self.log.warning("File server in maintenance mode")
             return False
         return True


### PR DESCRIPTION
Hello 👋🏻

Bunkr has performing a large scale maintenance recently, and I've noticed that I would on occasion download a file only to get a short "server is in maintenance video" instead of the intended file.

Debug logs show the filename for the maintenance video has changed:
```
[urllib3.connectionpool][debug] Starting new HTTPS connection (1): 3d09xl1.b-cdn.net:443
[urllib3.connectionpool][debug] https://3d09xl1.b-cdn.net:443 "GET /c4f36040-bdd1-40b6-aea1-034dfbe88ba2/maint.mp4 HTTP/1.1" 200 322509
```

This commit fixes the detection of that file to properly send the "File server in maintenance mode" warning and bail out, instead of downloading an unintended file.

Note that I'm not sure if the new file is a complete replacement, or if it's still possible to get the old maintenance file (e.g. on older bunkr servers / files, or something like that). Which is why I'm keeping the check on the old name as well, instead of replacing it.