### PR TITLE
[tiktok] Restructure to allow user extractors to provide their own rehydration data

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -329,7 +329,7 @@ class TiktokPostExtractor(TiktokExtractor):
     def posts(self):
         user, post_id = self.groups
         url = f"{self.root}/@{user or ''}/video/{post_id}"
-        return { url: None }
+        return {url: None}
 
 
 class TiktokVmpostExtractor(TiktokExtractor):


### PR DESCRIPTION
Despite the fact that we can now accept `itemStruct` data from `item_list` responses, I've found out that the video URLs (extracted from said data, and from the rehydration data) expire very quickly, quickly enough that they go stale by the time we enter the `TiktokExtractor.items()` method, and TikTok refuses to serve the videos. I suspect that yielding posts we get from `item_list` responses also won't work, unless the `count` parameters we set are very low (1 or 2), which is less than ideal. So we're forced to request rehydration data every time, unless there's a solution I am missing.

I still thought it would be nice to get this change out of the way, though, as it makes it easier to reduce rehydration data requests in the future.