### PR TITLE
[tiktok] fix following extractor

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -178,8 +178,8 @@ class TiktokExtractor(Extractor):
     def _ensure_rehydration_data_app_context_cache_is_populated(self):
         if not self.rehydration_data_app_context_cache:
             self.rehydration_data_app_context_cache = \
-                self._extract_rehydration_data("https://www.tiktok.com/",
-                                               ["webapp.app-context"])
+                self._extract_rehydration_data(
+                    "https://www.tiktok.com/", ["webapp.app-context"])
 
     def _extract_sec_uid(self, profile_url, user_name):
         sec_uid = self._extract_id(


### PR DESCRIPTION
Whilst testing my other PRs, I noticed that the `TiktokFollowingExtractor` had broken. We only care about the `webapp.app-context` object for this extractor anyway, so I've opted to extract it directly using `_extract_rehydration_data` instead of via `_extract_rehydration_data_user`.