### PR TITLE
Motherless extractor: fix gallery media metadata issues

### DIFF
--- a/gallery_dl/extractor/motherless.py
+++ b/gallery_dl/extractor/motherless.py
@@ -91,8 +91,8 @@ class MotherlessExtractor(Extractor):
             title = self._extract_gallery_title(page, gid)
         else:
             title = self._extract_group_title(page, gid)
-
-        creator = text.remove_html(extr(f'class="{category}-member-username">', "</"))
+        creator = text.remove_html(extr(
+            f'class="{category}-member-username">', "</"))
 
         return {
             category + "_id": gid,


### PR DESCRIPTION
> [!CAUTION]
> Links in this PR are NSFW by nature of the website and surrounding material, though I've tried to use a less NSFW URL as an example.

The current extractor has two metadata issues when used through a gallery:

1. Metadata isn't retrieved for photos
2. Any metadata retrieved for the file is clobbered by the gallery's metadata, most notably `uploader`

I don't think `file.update(data)` is the way to go here, but I also noticed both of these problems were somewhat addressed for the group extractor anyway, so I copied that logic in the gallery extractor.

The example is run on a gallery by `seanbowve`, containing one photo that was uploaded by `pepsibackbaby`.

### Before

```
$ gallery-dl -K https://motherless.com/G8978F51
Keywords for --chapter-filter:
------------------------------
category
  motherless
subcategory
  gallery

Keywords for directory names:
-----------------------------
category
  motherless
count
  1
gallery_id
  8978F51
gallery_title
  ##Repro Gallery##
id
  26AF63A
num
  1
subcategory
  gallery
thumbnail
  https://cdn5-thumbs.motherlessmedia.com/thumbs/26AF63A.jpg
title
  Avril Lavigne/sexy/as/hell/legs
type
  image
uploader
  seanbowve # <=== incorrect, should be pepsibackbaby
url
  https://cdn5-images.motherlessmedia.com/images/26AF63A.jpg

Keywords for filenames and --filter:
------------------------------------
category
  motherless
count
  1
extension
  jpg
filename
  26AF63A
gallery_id
  8978F51
gallery_title
  ##Repro Gallery##
id
  26AF63A
num
  1
subcategory
  gallery
thumbnail
  https://cdn5-thumbs.motherlessmedia.com/thumbs/26AF63A.jpg
title
  Avril Lavigne/sexy/as/hell/legs
type
  image
uploader
  seanbowve # <=== incorrect, should be pepsibackbaby
url
  https://cdn5-images.motherlessmedia.com/images/26AF63A.jpg

```

### After

```
$ gallery-dl -K https://motherless.com/G8978F51
Keywords for --chapter-filter:
------------------------------
category
  motherless
subcategory
  gallery

Keywords for directory names:
-----------------------------
category
  motherless
count
  1
date
  2013-03-13 00:00:00
favorites
  2
gallery_creator
  seanbowve
gallery_id
  8978F51
gallery_title
  ##Repro Gallery##
group
  
id
  26AF63A
num
  1
subcategory
  gallery
tags[N]
  0 avril
  1 Lavigne/sexy/as/hell/legs
  2 boobs
thumbnail
  https://cdn5-thumbs.motherlessmedia.com/thumbs/26AF63A.jpg
title
  Avril Lavigne/sexy/as/hell/legs
type
  image
uploader
  pepsibackbaby
url
  https://cdn5-images.motherlessmedia.com/images/26AF63A.jpg
views
  101

Keywords for filenames and --filter:
------------------------------------
category
  motherless
count
  1
date
  2013-03-13 00:00:00
extension
  jpg
favorites
  2
filename
  26AF63A
gallery_creator
  seanbowve
gallery_id
  8978F51
gallery_title
  ##Repro Gallery##
group
  
id
  26AF63A
num
  1
subcategory
  gallery
tags[N]
  0 avril
  1 Lavigne/sexy/as/hell/legs
  2 boobs
thumbnail
  https://cdn5-thumbs.motherlessmedia.com/thumbs/26AF63A.jpg
title
  Avril Lavigne/sexy/as/hell/legs
type
  image
uploader
  pepsibackbaby
url
  https://cdn5-images.motherlessmedia.com/images/26AF63A.jpg
views
  101
```