### PR TITLE
[deviantart] Update filename format to wfdownloader style with proper…

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -29,7 +29,7 @@ class DeviantartExtractor(Extractor):
     category = "deviantart"
     root = "https://www.deviantart.com"
     directory_fmt = ("{category}", "{username}")
-    filename_fmt = "{category}_{index}_{title}.{extension}"
+    filename_fmt = "[{date:%Y-%m-%d}] {title} by {username} - {num:>02} {index}.{extension}"
     cookies_domain = ".deviantart.com"
     cookies_names = ("auth", "auth_secure", "userinfo")
     _last_request = 0
@@ -261,6 +261,10 @@ class DeviantartExtractor(Extractor):
             deviation["published_time"])
         deviation["date"] = self.parse_timestamp(
             deviation["published_time"])
+
+        # Set default num field for single-file deviations
+        if "num" not in deviation:
+            deviation["num"] = 1
 
         if self.comments:
             deviation["comments"] = (
@@ -1149,7 +1153,7 @@ class DeviantartStatusExtractor(DeviantartExtractor):
     """Extractor for an artist's status updates"""
     subcategory = "status"
     directory_fmt = ("{category}", "{username}", "Status")
-    filename_fmt = "{category}_{index}_{title}_{date}.{extension}"
+    filename_fmt = "[{date:%Y-%m-%d}] {title} by {username} - {num:>02} {index}.{extension}"
     archive_fmt = "S_{_username}_{index}.{extension}"
     pattern = BASE_PATTERN + r"/posts/statuses"
     example = "https://www.deviantart.com/USER/posts/statuses/"
@@ -1191,6 +1195,10 @@ class DeviantartStatusExtractor(DeviantartExtractor):
 
         deviation["date"] = d = self.parse_datetime_iso(deviation["ts"])
         deviation["published_time"] = int(dt.to_ts(d))
+
+        # Set default num field for status updates
+        if "num" not in deviation:
+            deviation["num"] = 1
 
         deviation["da_category"] = "Status"
         deviation["category_path"] = "status"
@@ -1292,8 +1300,8 @@ class DeviantartDeviationExtractor(DeviantartExtractor):
             yield deviation
             return
 
-        self.filename_fmt = ("{category}_{index}_{index_file}_{title}_"
-                             "{num:>02}.{extension}")
+        self.filename_fmt = ("[{date:%Y-%m-%d}] {title} by {username} - "
+                             "{num:>02} {index}.{extension}")
         self.archive_fmt = ("g_{_username}_{index}{index_file:?_//}."
                             "{extension}")
 


### PR DESCRIPTION
… sorting

Changes:
- Update default filename format from "{category}_{index}_{title}.{extension}" to "[{date:%Y-%m-%d}] {title} by {username} - {num:>02} {index}.{extension}"
- Apply same format to status updates and multi-image deviations
- Add default num=1 initialization for single-file deviations

Improvements:
- More human-readable filenames with date, title, and author
- Zero-padded num field ({num:>02}) ensures proper alphabetical sorting (01, 02, 03... instead of 1, 10, 2...)
- Maintains full support for multi-image posts/albums via additionalMedia

Multi-image album support:
- Existing additionalMedia extraction logic is preserved (line 1298)
- Each image in an album gets incremented num: 01, 02, 03, etc.
- All images from multi-image posts are downloaded correctly

Example output:
- Single: [2024-11-05] My Artwork by artist - 01 118585512.jpg
- Album:  [2024-11-05] My Album by artist - 01 118585512.jpg [2024-11-05] My Album by artist - 02 118585512.jpg [2024-11-05] My Album by artist - 03 118585512.jpg

Users can override via config:
{"extractor": {"deviantart": {"filename": "{category}_{index}_{title}.{extension}"}}}