### PR TITLE
[tiktok] extract more story item list pages

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -868,7 +868,7 @@ class TiktokItemCursor(TiktokPaginationCursor):
         # anyway.
         self.cursor += len(data[self.list_key])
         if "hasMore" in data:
-            return data["hasMore"]
+            return not data["hasMore"]
         return not data.get("HasMoreAfter", False)
 
 


### PR DESCRIPTION
Story item list responses do not include `hasMore`. We should use `HasMoreAfter` instead.

Closes #8924.