### PR TITLE
[tiktok] do not fail story extraction if user has no stories

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -913,7 +913,7 @@ class TiktokItemCursor(TiktokPaginationCursor):
         # Sometimes less items are returned than what was requested in the
         # count parameter! We could fall back onto the count query parameter
         # but we could miss out on some posts.
-        self.cursor += len(data.get(self.list_key, []))
+        self.cursor += len(data.get(self.list_key, ()))
         if "hasMore" in data:
             return not data["hasMore"]
         return not data.get("HasMoreAfter", False)


### PR DESCRIPTION
If a user does not have any stories posted, then the request for story items won't include an item list. With the current code, this results in an extraction error, but we should report the lack of story items more gracefully.