### PR TITLE
[tiktok] do not exit account extraction early when we need to manually roll back the cursor

### DIFF
--- a/gallery_dl/extractor/tiktok.py
+++ b/gallery_dl/extractor/tiktok.py
@@ -223,7 +223,7 @@ class TiktokExtractor(Extractor):
             data = data["webapp.user-detail"]
         if not self._check_status_code(data, profile_url, "profile"):
             raise exception.ExtractionError(
-                "%s: could not extract rehydration data", profile_url)
+                f"{profile_url}: could not extract rehydration data")
         try:
             for key in additional_keys:
                 data = data[key]


### PR DESCRIPTION
In very rare edge cases, it is possible for TikTok to return no items from a `creator/item_list` request, whilst indicating that there are more items with the `hasMorePrevious: true` flag.

The `yt-dlp` code our extractor took inspiration from addressed this by manually rolling back the cursor. This is something we also carry out (see `TiktokLegacyTimeCursor.next_page()`), but there was a fault in the logic within `TiktokItemListRequest.extract_items()` that caused account extraction to exit early if it encountered no items, even if `hasMorePrevious` was `true`.

This PR addresses the fault by only exiting account extraction early if we encounter no items _and_ TikTok indicates that no more posts are available. An item counter was added alongside the page logs to give users a better understanding of the extraction's progress.

It is worth noting that manually rolling back the cursor is something the TikTok website does not do, which causes affected accounts to have an empty or partial list of posts on their page, despite the user having posts uploaded to their account.