### PR TITLE
Add Floorp browser support

### DIFF
--- a/gallery_dl/cookies.py
+++ b/gallery_dl/cookies.py
@@ -288,7 +288,7 @@ def _firefox_browser_directory(browser_name):
             "firefox"  : join(home, R".mozilla/firefox"),
             "librewolf": join(home, R".librewolf"),
             "zen"      : join(home, R".zen"),
-            "floorp"  : join(home, R".floorp"),
+            "floorp"   : join(home, R".floorp"),
         }[browser_name]
 
 


### PR DESCRIPTION
Add support for the Floorp browser.

Please let me know if anything else is needed besides adding its name and profiles directory to SUPPORTED_BROWSERS_FIREFOX and -firefox_browser_directory.