### PR TITLE
Make format parser more lenient

### DIFF
--- a/gallery_dl/formatter.py
+++ b/gallery_dl/formatter.py
@@ -289,6 +289,7 @@ def parse_field_name(field_name):
         return "_lit", (operator.itemgetter(field_name[1:-1]),)
 
     first, rest = _string.formatter_field_name_split(field_name)
+    first = first.strip()
     funcs = []
 
     for is_attr, key in rest:

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -63,6 +63,7 @@ class TestFormatter(unittest.TestCase):
         "title2": "",
         "title3": None,
         "title4": 0,
+        "num": 7,
     }
 
     def test_conversions(self):
@@ -134,6 +135,13 @@ class TestFormatter(unittest.TestCase):
         self._run_test("{name}{title4}", "Name0")
         self._run_test("{name}{title4:?//}", "Name")
         self._run_test("{name}{title4:? **/''/}", "Name")
+
+    def test_zero_fill(self):
+        self._run_test("{name}{num}", "Name7")
+        self._run_test("{name}{num:02}", "Name07")
+        self._run_test("{name}{num :02}", "Name07")
+        self._run_test("{name}{ num:02}", "Name07")
+        self._run_test("{name}{ num :02}", "Name07")
 
     def test_missing(self):
         replacement = "None"


### PR DESCRIPTION
I tried writing `{num :02}` in a format string.  This works in standard Python f-strings.  But in `gallery-dl`, it fails, raising an exception or else inserting the string `None` depending on how it is used.

This is because the variable name `num ` (with trailing space) is looked up in the dictionary.

I've added a one-line fix to the format parser to strip leading and trailing whitespace from variable names before compiling the formatter, and unit tests to check that `{num :02}` and similar are handled properly.

The tests still pass.

