### PR TITLE
[foolfuuka] improve media link resolution and post filtering

### DIFF
--- a/gallery_dl/extractor/foolfuuka.py
+++ b/gallery_dl/extractor/foolfuuka.py
@@ -33,11 +33,12 @@ class FoolfuukaExtractor(BaseExtractor):
     def items(self):
         yield Message.Directory, "", self.metadata()
         for post in filter(lambda p: p.get("media"), self.posts()):
+            board = post["board"]["shortname"]
             media = post["media"]
             url = media["media_link"]
 
             if not url and "remote_media_link" in media:
-                url = self.remote(media)
+                url = self.remote(board, media)
             if url and url[0] == "/":
                 url = self.root + url
 
@@ -54,8 +55,10 @@ class FoolfuukaExtractor(BaseExtractor):
     def posts(self):
         """Return an iterable with all relevant posts"""
 
-    def remote(self, media):
+    def remote(self, board, media):
         """Resolve a remote media link"""
+        if board in ["wsg", "gif"]:
+            return f"https://i.4cdn.org/{board}/{media['media_orig']}"
         page = self.request(media["remote_media_link"]).text
         url = text.extr(page, 'http-equiv="Refresh" content="0; url=', '"')
 
@@ -82,7 +85,6 @@ class FoolfuukaExtractor(BaseExtractor):
                 "sci": "warosu.org",
                 "tg" : "archive.4plebs.org",
             }
-            board = url.split("/", 4)[3]
             if board in board_domains:
                 domain = board_domains[board]
                 url = f"https://{domain}/{board}/full_image/{filename}"
@@ -96,7 +98,7 @@ class FoolfuukaExtractor(BaseExtractor):
 
         return url
 
-    def _remote_direct(self, media):
+    def _remote_direct(self, board, media):
         return media["remote_media_link"]
 
 


### PR DESCRIPTION
This improves performance for posts on `wsg` and `gif` boards and simplifies the extractor logic.

Foolfuuka archives do not store media from `wsg` and `gif` boards, so once a file is removed from 4chan's CDN, it is permanently lost. However, threads from these boards are often archived or deleted while the media still remains on the CDN for some time. Fetching each file individually in these cases is slow, frequently triggers 429 rate-limit responses, or fails due to Cloudflare verification expiring.

### Changes

- Skip posts without media using `filter` to simplify iteration.
- Pass board explicitly to `remote` and `_remote_direct` methods to eliminate the need to parse the board from the URL `url.split("/", 4)[3]`.
  - This makes board-specific URL handling deterministic and avoids fragile string manipulation.
- Add early resolution for `wsg` and `gif` boards to construct direct URLs instead of fetching remote pages.

### Notes

Ideally, more cases could be handled this way, but Foolfuuka archives are inconsistent across different instances. For example, on the `wsg` and `gif` boards:
- <https://archived.moe> - provides no `media["media_link"]` and its `media["remote_media_link"]` is a redirect.
- <https://desuarchive.org> - provides no `media["remote_media_link"]` and its `media["media_link"]` returns 404.