### PR TITLE
fix: honor metadata-http alias and prevent stale path reuse

### DIFF
--- a/gallery_dl/downloader/common.py
+++ b/gallery_dl/downloader/common.py
@@ -51,6 +51,12 @@ class DownloaderBase():
         """Interpolate downloader config value for 'key'"""
         return config.interpolate(("downloader", self.scheme), key, default)
 
+    def config2(self, key, key2, default=None, sentinel=util.SENTINEL):
+        value = self.config(key, sentinel)
+        if value is not sentinel:
+            return value
+        return self.config(key2, default)
+
     def config_opts(self, key, default=None, conf=_config):
         if key in conf:
             return conf[key]

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -27,7 +27,9 @@ class HttpDownloader(DownloaderBase):
 
         self.adjust_extension = self.config("adjust-extensions", True)
         self.chunk_size = self.config("chunk-size", 32768)
-        self.metadata = extractor.config("http-metadata")
+        metadata = extractor.config2("http-metadata", "metadata-http")
+        self.metadata = self.config2(
+            "http-metadata", "metadata-http", metadata)
         self.progress = self.config("progress", 3.0)
         self.validate = self.config("validate", True)
         self.validate_html = self.config("validate-html", True)

--- a/gallery_dl/output.py
+++ b/gallery_dl/output.py
@@ -127,7 +127,11 @@ class PathfmtProxy():
 
     def __str__(self):
         if pathfmt := object.__getattribute__(self, "job").pathfmt:
-            return pathfmt.path or pathfmt.directory
+            if pathfmt.path:
+                return pathfmt.path
+            if pathfmt.filename:
+                return pathfmt.directory + pathfmt.filename
+            return pathfmt.directory
         return ""
 
 

--- a/gallery_dl/path.py
+++ b/gallery_dl/path.py
@@ -223,7 +223,8 @@ class PathFormat():
     def set_filename(self, kwdict):
         """Set general filename data"""
         self.kwdict = kwdict
-        self.filename = self.temppath = self.prefix = ""
+        self.filename = self.path = self.realpath = self.temppath = \
+            self.prefix = ""
 
         ext = kwdict["extension"]
         kwdict["extension"] = self.extension = self.extension_map(ext, ext)

--- a/test/test_downloader.py
+++ b/test/test_downloader.py
@@ -166,6 +166,20 @@ class TestDownloaderConfig(unittest.TestCase):
         self.assertEqual(dl.rate(), 42)
         self.assertEqual(dl.part, False)
 
+    def test_config_http_metadata_alias(self):
+        config.set(("extractor", "generic"), "metadata-http", "_meta_alias")
+        job = FakeJob()
+        dl = downloader.find("http")(job)
+        self.assertEqual(dl.metadata, "_meta_alias")
+
+    def test_config_http_metadata_downloader_override(self):
+        config.set(
+            ("extractor", "generic"), "http-metadata", "_meta_extractor")
+        config.set(("downloader", "http"), "metadata-http", "_meta_downloader")
+        job = FakeJob()
+        dl = downloader.find("http")(job)
+        self.assertEqual(dl.metadata, "_meta_downloader")
+
 
 class TestDownloaderBase(unittest.TestCase):
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -152,5 +152,35 @@ class TestShortenEAW(unittest.TestCase):
         self.assertEqual(f(s, 19, "")   , "幻-想-郷###幻-想-郷")
 
 
+class TestPathfmtProxy(unittest.TestCase):
+
+    def _proxy(self, path="", directory="", filename=""):
+        class Job:
+            pass
+
+        class Pathfmt:
+            pass
+
+        job = Job()
+        job.pathfmt = Pathfmt()
+        job.pathfmt.path = path
+        job.pathfmt.directory = directory
+        job.pathfmt.filename = filename
+        return output.PathfmtProxy(job)
+
+    def test_str_uses_path_when_available(self):
+        proxy = self._proxy(
+            path="a/b/c.ext", directory="a/b/", filename="c.ext")
+        self.assertEqual(str(proxy), "a/b/c.ext")
+
+    def test_str_falls_back_to_directory_and_filename(self):
+        proxy = self._proxy(path="", directory="a/b/", filename="c.ext")
+        self.assertEqual(str(proxy), "a/b/c.ext")
+
+    def test_str_falls_back_to_directory_only(self):
+        proxy = self._proxy(path="", directory="a/b/", filename="")
+        self.assertEqual(str(proxy), "a/b/")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -85,6 +85,20 @@ class TestPathObject(TestPath):
         self.assertEqual(str(pfmt), pfmt.realpath)
         self.assertEqual(str(pfmt), "./gallery-dl/test/file.ext")
 
+    def test_set_filename_resets_paths(self):
+        kwdict = KWDICT.copy()
+        pfmt = self._pfmt(kwdict=True)
+
+        pfmt.set_filename(kwdict)
+        pfmt.build_path()
+        self.assertTrue(pfmt.path)
+        self.assertTrue(pfmt.realpath)
+
+        kwdict["filename"] = "next"
+        pfmt.set_filename(kwdict)
+        self.assertEqual(pfmt.path, "")
+        self.assertEqual(pfmt.realpath, "")
+
 
 class TestPathOptions(TestPath):
 


### PR DESCRIPTION
## Summary
- Fix HTTP metadata option lookup so `metadata-http` is honored the same way as `http-metadata`, including downloader-level overrides.
- Reset per-file path state before each URL to prevent stale `path`/`realpath` reuse when path construction is deferred.
- Update path proxy fallback behavior to derive a current path string from `directory + filename` when `path` has not been built yet.

## File changes
- `gallery_dl/downloader/common.py`: add `config2()` helper for dual-key downloader config lookup.
- `gallery_dl/downloader/http.py`: resolve metadata key via both option names.
- `gallery_dl/path.py`: clear cached path fields in `set_filename()`.
- `gallery_dl/output.py`: improve `PathfmtProxy.__str__()` fallback.

## Test plan
- [x] `.venv/bin/python scripts/run_tests.py downloader path output`
- [x] `.venv/bin/flake8 gallery_dl/downloader/common.py gallery_dl/downloader/http.py gallery_dl/path.py gallery_dl/output.py test/test_downloader.py test/test_path.py test/test_output.py`
- issue: https://github.com/mikf/gallery-dl/issues/7661
