### PR TITLE
[Instagram]: fall back to web_profile_info when topsearch misses user

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -910,10 +910,11 @@ class InstagramRestAPI():
             if user := self.user_by_search(screen_name):
                 return user
             self.user_by_search.invalidate(screen_name)
-        else:
-            if user := self.user_by_name(screen_name):
-                return user
-            self.user_by_name.invalidate(screen_name)
+
+        if user := self.user_by_name(screen_name):
+            return user
+        self.user_by_name.invalidate(screen_name)
+
         raise exception.NotFoundError("user")
 
     def user_id(self, screen_name, check_private=True):


### PR DESCRIPTION
When user-strategy is set to topsearch, search may return no exact
match, causing fail with NotFoundError.
After an unsuccessful topsearch lookup, fall back to the web_profile_info to resolve the user ID.