### PR TITLE
fix: rollback queue counters for blacklisted child URLs

### DIFF
--- a/gallery_dl/extractor/bellazon.py
+++ b/gallery_dl/extractor/bellazon.py
@@ -8,7 +8,7 @@
 
 """Extractors for https://www.bellazon.com/"""
 
-from .common import Extractor, Message
+from .common import Extractor, Message, mark_queue_rollback
 from .. import text
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?bellazon\.com/main"
@@ -48,6 +48,11 @@ class BellazonExtractor(Extractor):
 
             yield Message.Directory, "", data
             data["num"] = data["num_internal"] = data["num_external"] = 0
+            mark_queue_rollback(
+                data,
+                ("num", "num_external", "count"),
+                ("post.count",),
+            )
             for info, url, url_img in urls:
                 if url_img:
                     url = text.unescape(

--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -26,6 +26,15 @@ from .. import config, output, text, util, dt, cache, exception
 urllib3 = requests.packages.urllib3
 
 
+def mark_queue_rollback(data, counters=(), nested=()):
+    """Annotate Queue metadata with rollback fields for skipped children."""
+    if counters:
+        data[Message.QueueRollback] = counters
+    if nested:
+        data[Message.QueueRollbackNested] = nested
+    return data
+
+
 class Extractor():
 
     category = ""

--- a/gallery_dl/extractor/message.py
+++ b/gallery_dl/extractor/message.py
@@ -41,6 +41,15 @@ class Message():
       - 2nd element is the (external) URL as a string
       - 3rd element is a dictionary containing URL-specific metadata
 
+      Optional metadata keys for Queue messages:
+      - Message.QueueRollback:
+        - Tuple/list of top-level integer metadata fields that should be
+          decremented if queue handling gets skipped (for example due to an
+          extractor blacklist).
+      - Message.QueueRollbackNested:
+        - Tuple/list of dotted metadata paths (e.g. "post.count") that should
+          be decremented under the same conditions.
+
     - Message.Urllist:  # obsolete
       - Same as Message.Url, but its 2nd element is a list of multiple URLs
       - The additional URLs serve as a fallback if the primary one fails
@@ -52,5 +61,7 @@ class Message():
     #  Headers = 4
     #  Cookies = 5
     Queue = 6
+    QueueRollback = "_queue_rollback"
+    QueueRollbackNested = "_queue_rollback_nested"
     #  Urllist = 7
     #  Metadata = 8

--- a/gallery_dl/extractor/xenforo.py
+++ b/gallery_dl/extractor/xenforo.py
@@ -8,7 +8,7 @@
 
 """Extractors for XenForo forums"""
 
-from .common import BaseExtractor, Message
+from .common import BaseExtractor, Message, mark_queue_rollback
 from .. import text, util
 from ..cache import cache
 import binascii
@@ -62,6 +62,11 @@ class XenforoExtractor(BaseExtractor):
             data["_http_expected_status"] = (403,)
             data["_http_validate"] = self._validate
             data["num"] = data["num_internal"] = data["num_external"] = 0
+            mark_queue_rollback(
+                data,
+                ("num", "num_external", "count"),
+                ("post.count",),
+            )
             for video, inl, bb, ext in urls:
                 if ext:
                     if ext[0] == "#":


### PR DESCRIPTION
## Summary
- add queue rollback metadata markers for extractors that pre-increment counters for external links
- rollback queue counter fields when child queue entries are skipped by blacklist filtering
- wire rollback markers into Bellazon and XenForo external-link queue paths
- add job-level regression tests for filtered vs non-filtered queue handling

## What changed
- gallery_dl/job.py: rollback queue counters on filtered and duplicate queue skips
- gallery_dl/extractor/message.py: define queue rollback metadata keys
- gallery_dl/extractor/common.py: helper to annotate queue rollback metadata
- gallery_dl/extractor/bellazon.py: mark external queue counters for rollback
- gallery_dl/extractor/xenforo.py: mark external queue counters for rollback
- test/test_job.py: add regression coverage for queue counter rollback

## Test plan
- ./.venv/bin/python -m pytest test/test_job.py

Fixes #8513
