### PR TITLE
fix: skip invalid deviantart download targets without src

### DIFF
--- a/gallery_dl/extractor/common.py
+++ b/gallery_dl/extractor/common.py
@@ -26,6 +26,17 @@ from .. import config, output, text, util, dt, cache, exception
 urllib3 = requests.packages.urllib3
 
 
+def media_source(data, *keys):
+    """Return the first non-empty media URL value from a mapping."""
+    if not isinstance(data, dict):
+        return ""
+    for key in keys:
+        value = data.get(key)
+        if value:
+            return value
+    return ""
+
+
 class Extractor():
 
     category = ""

--- a/gallery_dl/extractor/shopify.py
+++ b/gallery_dl/extractor/shopify.py
@@ -8,7 +8,7 @@
 
 """Extractors for Shopify instances"""
 
-from .common import BaseExtractor, Message
+from .common import BaseExtractor, Message, media_source
 from .. import text
 
 
@@ -24,11 +24,19 @@ class ShopifyExtractor(BaseExtractor):
 
         for product in self.products():
             for num, image in enumerate(product.pop("images"), 1):
-                text.nameext_from_url(image["src"], image)
+                url = media_source(image, "src", "url")
+                if not url:
+                    self.log.warning(
+                        "%s: image payload has no media source URL",
+                        product.get("id", "?"),
+                    )
+                    continue
+
+                text.nameext_from_url(url, image)
                 image.update(data)
                 image["product"] = product
                 image["num"] = num
-                yield Message.Url, image["src"], image
+                yield Message.Url, url, image
 
     def metadata(self):
         """Return general metadata"""

--- a/test/test_deviantart.py
+++ b/test/test_deviantart.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Mike Fährmann
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from gallery_dl import exception  # noqa E402
+from gallery_dl.extractor.deviantart import (  # noqa E402
+    DeviantartDeviationExtractor,
+    DeviantartOAuthAPI,
+)
+
+
+class TestDeviantartMediaSourceHandling(unittest.TestCase):
+
+    def _extractor(self):
+        return DeviantartDeviationExtractor.from_url(
+            "https://www.deviantart.com/user/art/title-12345")
+
+    def test_commit_skips_target_without_media_source(self):
+        extr = self._extractor()
+
+        deviation = {"filename": "sample", "deviationid": "uuid-1"}
+        self.assertIsNone(extr.commit(deviation, {"error": "forbidden"}))
+
+    def test_update_content_default_keeps_preview_on_auth_errors(self):
+        extr = self._extractor()
+
+        def _raise_auth(*_args, **_kwargs):
+            raise exception.AuthorizationError(
+                "Only subscribers may have access to this download.")
+
+        extr.api = types.SimpleNamespace(deviation_download=_raise_auth)
+
+        deviation = {"deviationid": "uuid-2"}
+        content = {"src": "https://example.invalid/preview.jpg"}
+
+        extr._update_content_default(deviation, content)
+
+        self.assertEqual(content["src"], "https://example.invalid/preview.jpg")
+        self.assertNotIn("is_original", deviation)
+
+    def test_api_download_raises_authorization_when_payload_has_no_source(self):
+        extr = self._extractor()
+        extr.extra = False
+        api = DeviantartOAuthAPI(extr)
+        api._call = lambda *_args, **_kwargs: {
+            "error": "forbidden",
+            "error_description":
+            "Only subscribers may have access to this download.",
+        }
+
+        with self.assertRaises(exception.AuthorizationError):
+            api.deviation_download("uuid-3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid hard failures when DeviantArt download payloads do not include a media source URL
- treat non-downloadable payloads as authorization failures and continue extraction safely
- add shared media-source resolution helper and apply it to other extractors that previously assumed src was always present
- add focused regression tests for DeviantArt source-missing behavior

## What changed
- gallery_dl/extractor/deviantart.py: skip invalid targets, validate download payloads, and handle restricted downloads without crashing
- gallery_dl/extractor/common.py: add media_source() helper for defensive URL extraction
- gallery_dl/extractor/shopify.py: skip image entries without source URL
- gallery_dl/extractor/pexels.py: guard missing video/image source links
- gallery_dl/extractor/newgrounds.py: guard missing source URLs in video format selection
- test/test_deviantart.py: regression tests for missing-source and authorization paths

## Test plan
- ./.venv/bin/python -m pytest test/test_deviantart.py test/test_job.py

Fixes #9072
