### PR TITLE
[kemono] fix default coomer file order

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2457,6 +2457,20 @@ Description
     |ISO 639-1| code(s) to filter chapters by.
 
 
+extractor.coomer.files
+----------------------
+Type
+    ``list`` of ``strings``
+Default
+    ``["file", "attachments", "inline"]``
+Description
+    Determines the type and order of files to be downloaded.
+Available Types
+    * ``file``
+    * ``attachments``
+    * ``inline``
+
+
 extractor.cyberdrop.domain
 --------------------------
 Type

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -244,7 +244,7 @@
             "dms"          : false,
             "duplicates"   : false,
             "favorites"    : "artist",
-            "files"        : ["attachments", "file", "inline"],
+            "files"        : ["file", "attachments", "inline"],
             "max-posts"    : null,
             "metadata"     : false,
             "revisions"    : false,

--- a/gallery_dl/extractor/kemono.py
+++ b/gallery_dl/extractor/kemono.py
@@ -233,6 +233,8 @@ class KemonoExtractor(Extractor):
 
     def _build_file_generators(self, filetypes):
         if filetypes is None:
+            if self.category == "coomer":
+                return (self._file, self._attachments, self._inline)
             return (self._attachments, self._file, self._inline)
         genmap = {
             "file"       : self._file,


### PR DESCRIPTION
I noticed the file order was wrong for coomer posts. For OnlyFans, `file` is first in a few cases I looked at (I checked both coomer & OnlyFans itself) and for Fansly `file` seems to always be empty anyway.

I'm pretty sure this change will result in different outputs for every OnlyFans post with more than 1 file, but it'll be more correct with it :sweat_smile: (but I understand if this means you don't want the change)

I understand it was intentionally set the way it is for kemono, so I've just changed the default for coomer & added it to the docs. Hope I did it correctly!