### PR TITLE
docs: schalenetwork.tags default to `false`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5768,7 +5768,7 @@ extractor.schalenetwork.tags
 Type
     ``bool``
 Default
-    ``true``
+    ``false``
 Description
     Group ``tags`` by type and
     provide them as ``tags_<type>`` metadata fields,


### PR DESCRIPTION
Default behavior is actually `false` not `true`.