### PR TITLE
Implement optional aria2c HTTP downloader with validation and tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Dependencies
 Optional
 --------
 
+- aria2c_: Optional high-throughput HTTP downloader backend
 - yt-dlp_ or youtube-dl_: HLS/DASH video downloads, ``ytdl`` integration
 - FFmpeg_: Pixiv Ugoira conversion
 - mkvmerge_: Accurate Ugoira frame timecodes
@@ -298,6 +299,38 @@ can be found at `<https://gdl-org.github.io/docs/configuration.html>`__.
   see `<docs/gallery-dl-example.conf>`__.
 
 
+HTTP Downloader Backend (aria2c)
+--------------------------------
+
+*gallery-dl* can optionally use `aria2c`_ as its HTTP downloader for
+eligible single-file downloads.
+
+This is useful when you want aria2c's multi-connection transfer behavior
+while keeping *gallery-dl*'s normal extraction and naming logic.
+The built-in downloader remains the default, and *gallery-dl* falls back to
+it automatically for downloads that need direct response handling.
+
+1. Install ``aria2c`` so it is available on your ``PATH``
+2. Enable it in your config file:
+
+.. code:: json
+
+    {
+        "downloader": {
+            "http": {
+                "aria2c": true
+            }
+        }
+    }
+
+If ``aria2c`` is not on your ``PATH``, you can also set the absolute path to
+the executable instead of ``true``.
+
+See
+`downloader.http.aria2c <https://gdl-org.github.io/docs/configuration.html#downloader-http-aria2c>`__
+for the full option reference, tuning details, and fallback behavior.
+
+
 Locations
 ---------
 
@@ -471,6 +504,7 @@ To authenticate with a ``mastodon`` instance, run *gallery-dl* with
 .. _PyPI:       https://pypi.org/
 .. _pip:        https://pip.pypa.io/en/stable/
 .. _Requests:   https://requests.readthedocs.io/en/latest/
+.. _aria2c:     https://aria2.github.io/
 .. _FFmpeg:     https://www.ffmpeg.org/
 .. _mkvmerge:   https://www.matroska.org/downloads/mkvtoolnix.html
 .. _yt-dlp:     https://github.com/yt-dlp/yt-dlp

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -8092,6 +8092,86 @@ Description
     when expecting a media file instead.
 
 
+downloader.http.aria2c
+----------------------
+Type
+    * ``bool``
+    * ``string``
+Default
+    ``false``
+Example
+    ``true``, ``"/usr/local/bin/aria2c"``
+Description
+    Use `aria2c <https://aria2.github.io/>`__ as the HTTP download engine
+    instead of the built-in streaming downloader.
+
+    Set to ``true`` to use ``aria2c`` from ``PATH``,
+    or set to the absolute path of the ``aria2c`` binary.
+
+    **Quick start**
+
+    .. code:: json
+
+        {
+            "downloader": {
+                "http": {
+                    "aria2c": true
+                }
+            }
+        }
+
+    With this setting, gallery-dl will prefer ``aria2c`` for eligible
+    HTTP/HTTPS file downloads while keeping the built-in downloader as the
+    automatic fallback for everything else.
+
+    When enabled, gallery-dl invokes ``aria2c`` as a subprocess for each
+    eligible download.  The following session context is forwarded
+    automatically:
+
+    - HTTP headers (including ``User-Agent``)
+    - Session cookies
+    - Proxy settings (``downloader.*.proxy``)
+    - SSL certificate verification (``downloader.*.verify``)
+
+    For throughput, gallery-dl uses the following aria2c tuning flags by
+    default for each eligible single-file download:
+
+    - ``--split=16``
+    - ``--max-connection-per-server=16``
+    - ``--min-split-size=1M``
+    - ``--file-allocation=none``
+
+    This biases aria2c toward maximum download speed by opening multiple
+    parallel HTTP ranges against the same file and avoiding preallocation
+    overhead.
+
+    Partial-download resumption is supported: if a previous ``aria2c``
+    download was interrupted (leaving an ``.aria2`` control file alongside
+    the ``.part`` file), the download will be resumed automatically.
+
+    **Limitations / automatic fallback to built-in downloader**
+
+    aria2c is used only for plain HTTP/HTTPS ``GET`` requests with a known
+    filename extension.  The following cases always fall back to the
+    built-in downloader transparently:
+
+    - Non-``GET`` methods (e.g. ``POST``)
+    - Downloads that use a request body (``_http_data``)
+    - Downloads that require custom response-object validation
+      (``_http_validate`` / ``_http_retry`` / ``_http_expected_status``)
+    - Downloads where the filename extension must be inferred from the
+      ``Content-Type`` response header (``metadata`` / unknown extension)
+    - Segmented downloads (``_http_segmented``)
+
+    If ``aria2c`` cannot be found at the configured path, a warning is
+    logged and the built-in downloader is used for all subsequent downloads
+    in that session.
+
+    ``Last-Modified``-based ``mtime`` stamping is not available when using
+    aria2c because the HTTP response headers are not accessible after the
+    subprocess exits.
+
+
 downloader.ytdl.cmdline-args
 ----------------------------
 Type

--- a/docs/gallery-dl-example.conf
+++ b/docs/gallery-dl-example.conf
@@ -343,6 +343,13 @@
         "#": "do not update file modification times",
         "mtime": false,
 
+        "http":
+        {
+            "#": "use aria2c from PATH for eligible HTTP downloads",
+            "#": "gallery-dl falls back to the built-in downloader automatically",
+            "aria2c": true
+        },
+
         "ytdl":
         {
             "#": "use yt-dlp instead of youtube-dl",

--- a/docs/gallery-dl.conf
+++ b/docs/gallery-dl.conf
@@ -1273,6 +1273,7 @@
         "http":
         {
             "adjust-extensions": true,
+            "aria2c"           : false,
             "chunk-size"       : 32768,
             "consume-content"  : false,
             "enabled"          : true,

--- a/gallery_dl/downloader/http.py
+++ b/gallery_dl/downloader/http.py
@@ -8,13 +8,18 @@
 
 """Downloader module for http:// and https:// URLs"""
 
+import os
 import time
 import mimetypes
+import subprocess
+from requests import Request
 from requests.exceptions import RequestException, ConnectionError, Timeout
 from .common import DownloaderBase
 from .. import text, util, output, exception
 from ssl import SSLError
 FLAGS = util.FLAGS
+ARIA2C_SPLIT = 16
+ARIA2C_MIN_SPLIT_SIZE = "1M"
 
 
 class HttpDownloader(DownloaderBase):
@@ -96,8 +101,15 @@ class HttpDownloader(DownloaderBase):
                                interval_429, exc.__class__.__name__, exc)
                 self.interval_429 = extractor._interval_429
 
+        aria2c = self.config("aria2c", False)
+        if aria2c is True:
+            aria2c = "aria2c"
+        self._aria2c = aria2c
+
     def download(self, url, pathfmt):
         try:
+            if self._can_use_aria2c(pathfmt.kwdict):
+                return self._download_impl_aria2c(url, pathfmt)
             return self._download_impl(url, pathfmt)
         except Exception as exc:
             if self.downloading:
@@ -108,6 +120,252 @@ class HttpDownloader(DownloaderBase):
             # remove file from incomplete downloads
             if self.downloading and not self.part:
                 util.remove_file(pathfmt.temppath)
+
+    def _can_use_aria2c(self, kwdict):
+        """Return True when aria2c can handle this particular download"""
+        if not self._aria2c:
+            return False
+        # Only plain GET requests are supported
+        if kwdict.get("_http_method", "GET").upper() != "GET":
+            return False
+        # POST data cannot be forwarded to aria2c
+        if kwdict.get("_http_data"):
+            return False
+        # Response-object validators require the built-in path
+        if kwdict.get("_http_validate") is not None:
+            return False
+        # Custom per-response retry callbacks require the built-in path
+        if kwdict.get("_http_retry"):
+            return False
+        # Non-standard expected status codes need response inspection
+        if kwdict.get("_http_expected_status"):
+            return False
+        # Segmented downloads use specialised retry logic
+        if kwdict.get("_http_segmented"):
+            return False
+        # HTTP-metadata extraction requires response headers
+        if self.metadata:
+            return False
+        # Extension inference from MIME type requires response headers;
+        # fall back when the extension is unknown
+        if not kwdict.get("extension"):
+            return False
+        return True
+
+    def _remove_aria2c_file(self, pathfmt, path):
+        util.remove_file(path)
+        util.remove_file(path + ".aria2")
+        if pathfmt.temppath == path:
+            pathfmt.temppath = ""
+
+    def _download_impl_aria2c(self, url, pathfmt):
+        """Download *url* using aria2c as the backend.
+
+        Behaviour is kept as close as possible to _download_impl:
+        - retry loop is owned by Python
+        - partial-download / resume support via aria2c --continue
+        - post-download: file-size checks, signature validation,
+          and extension adjustment
+        Falls back to the built-in downloader when aria2c is not found.
+        """
+        tries = 0
+        msg = ""
+        kwdict = pathfmt.kwdict
+        adjust_extension = kwdict.get(
+            "_http_adjust_extension", self.adjust_extension)
+
+        # Save temppath so it can be restored on fallback (before part_enable
+        # has modified it).
+        saved_temppath = pathfmt.temppath
+
+        if self.part:
+            pathfmt.part_enable(self.partdir)
+
+        while True:
+            if FLAGS.DOWNLOAD is not None:
+                return FLAGS.process("DOWNLOAD")
+
+            if tries:
+                self.log.warning("%s (%s/%s)", msg, tries, self.retries+1)
+                if tries > self.retries:
+                    return False
+                time.sleep(tries)
+
+            tries += 1
+
+            # Resolve the output path for this iteration
+            outpath = pathfmt.temppath or pathfmt.realpath
+            outdir = os.path.dirname(os.path.abspath(outpath))
+            outfile = os.path.basename(outpath)
+            aria2_ctrl = outpath + ".aria2"
+
+            # A plain .part file left by the built-in downloader cannot be
+            # resumed by aria2c (no control file) – delete it so aria2c starts
+            # fresh.  If an aria2c control file is present we can resume.
+            can_resume = os.path.isfile(aria2_ctrl)
+            if os.path.isfile(outpath) and not can_resume:
+                util.remove_file(outpath)
+
+            # Collect HTTP headers based on how requests would prepare them
+            # for this URL. This forwards only URL-matching cookies.
+            headers = dict(self.session.prepare_request(
+                Request("GET", url)).headers)
+            headers["Accept"] = "*/*"
+            if extra := kwdict.get("_http_headers"):
+                headers.update(extra)
+            if self.headers:
+                headers.update(self.headers)
+
+            # Build the aria2c command (no shell – list form only)
+            cmd = [
+                self._aria2c,
+                "--no-conf",
+                "--quiet",
+                "--allow-overwrite=true",
+                "--auto-file-renaming=false",
+                f"--split={ARIA2C_SPLIT}",
+                f"--max-connection-per-server={ARIA2C_SPLIT}",
+                f"--min-split-size={ARIA2C_MIN_SPLIT_SIZE}",
+                "--file-allocation=none",
+                f"--dir={outdir}",
+                f"--out={outfile}",
+                "--max-tries=1",
+            ]
+
+            if can_resume:
+                cmd.append("--continue=true")
+
+            timeout = self.timeout[1] if isinstance(
+                self.timeout, tuple) else self.timeout
+            if timeout:
+                try:
+                    timeout = max(1, int(timeout))
+                except (TypeError, ValueError, OverflowError):
+                    self.log.warning("Invalid timeout value for aria2c (%r)",
+                                     timeout)
+                else:
+                    cmd.append(f"--timeout={timeout}")
+                    cmd.append(f"--connect-timeout={timeout}")
+
+            for name, value in headers.items():
+                cmd.append(f"--header={name}: {value}")
+
+            if self.proxies:
+                proxy = self.proxies.get("https") or self.proxies.get("http")
+                if proxy:
+                    cmd.append(f"--all-proxy={proxy}")
+
+            if not self.verify:
+                cmd.append("--check-certificate=false")
+
+            cmd.append(url)
+
+            # Invoke aria2c
+            self.downloading = True
+            self.out.start(pathfmt.path)
+            try:
+                proc = subprocess.run(cmd, capture_output=True)
+            except FileNotFoundError:
+                self.downloading = False
+                self.log.warning(
+                    "aria2c executable '%s' not found, "
+                    "falling back to built-in downloader", self._aria2c)
+                self._aria2c = None
+                # Restore temppath so _download_impl can call part_enable
+                # cleanly without double-appending ".part".
+                pathfmt.temppath = saved_temppath
+                return self._download_impl(url, pathfmt)
+            except OSError as exc:
+                self.downloading = False
+                self.log.warning(exc)
+                return False
+
+            if proc.returncode != 0:
+                stderr = proc.stderr.decode(errors="replace").strip()
+                if stderr:
+                    # Truncate to last 200 chars to avoid flooding the log
+                    msg = f"aria2c: {stderr[-200:]}"
+                else:
+                    msg = f"aria2c: exit code {proc.returncode}"
+                # Retry on transient network / server errors.
+                # aria2c exit codes: 2 = timeout, 6 = network problem,
+                # 7 = unfinished downloads, 8 = server error response,
+                # 23 = too many redirects.
+                if proc.returncode in (2, 6, 7, 8, 23):
+                    continue
+                self.downloading = False
+                output.stderr_write("\n")
+                self.log.warning(msg)
+                return False
+
+            # aria2c succeeded – remove its control file
+            util.remove_file(aria2_ctrl)
+            break
+
+        self.downloading = False
+
+        # Post-download validation (mirrors _download_impl behaviour)
+        try:
+            fsize = os.path.getsize(outpath)
+        except OSError:
+            self.log.warning("Downloaded file not found at '%s'", outpath)
+            return False
+
+        if not fsize:
+            self.log.warning("Empty file")
+            self._remove_aria2c_file(pathfmt, outpath)
+            return False
+
+        if self.minsize and fsize < self.minsize:
+            self.log.warning(
+                "File size smaller than allowed minimum (%s < %s)",
+                fsize, self.minsize)
+            self._remove_aria2c_file(pathfmt, outpath)
+            return True
+
+        if self.maxsize and fsize > self.maxsize:
+            self.log.warning(
+                "File size larger than allowed maximum (%s > %s)",
+                fsize, self.maxsize)
+            self._remove_aria2c_file(pathfmt, outpath)
+            return True
+
+        # File-signature validation and extension adjustment
+        validate_sig = kwdict.get("_http_signature")
+        validate_ext = (adjust_extension and
+                        pathfmt.extension in SIGNATURE_CHECKS)
+        validate_html = (self.validate_html and
+                         pathfmt.extension not in ("html", "htm"))
+
+        if validate_ext or validate_sig or validate_html:
+            try:
+                with open(outpath, "rb") as fp:
+                    file_header = fp.read(16)
+            except OSError as exc:
+                self.log.warning(exc)
+                return False
+
+            if validate_html and _signature_html(file_header):
+                self.log.warning("HTML response")
+                self._remove_aria2c_file(pathfmt, outpath)
+                return False
+
+            if validate_sig:
+                result = validate_sig(file_header)
+                if result is not True:
+                    self.log.warning(result or "Invalid file signature bytes")
+                    self._remove_aria2c_file(pathfmt, outpath)
+                    return False
+
+            if validate_ext and self._adjust_extension(
+                    pathfmt, file_header) and pathfmt.exists():
+                self._remove_aria2c_file(pathfmt, outpath)
+                return True
+
+        # aria2c does not expose response headers, so Last-Modified is
+        # unavailable; disable HTTP-based mtime for this download.
+        kwdict["_mtime_http"] = None
+        return True
 
     def _download_impl(self, url, pathfmt):
         response = None

--- a/test/test_downloader.py
+++ b/test/test_downloader.py
@@ -22,6 +22,7 @@ import http.server
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from gallery_dl import downloader, extractor, output, config, path  # noqa E402
+from gallery_dl.downloader import http as http_downloader  # noqa E402
 from gallery_dl.downloader.http import MIME_TYPES, SIGNATURE_CHECKS # noqa E402
 
 
@@ -134,6 +135,7 @@ class TestDownloaderConfig(unittest.TestCase):
         self.assertEqual(dl.rate, None)
         self.assertEqual(dl.part, True)
         self.assertEqual(dl.partdir, None)
+        self.assertEqual(dl._aria2c, False)
 
         self.assertIs(dl.interval_429, extr._interval_429)
         self.assertIs(dl.retry_codes, extr._retry_codes)
@@ -167,8 +169,211 @@ class TestDownloaderConfig(unittest.TestCase):
         self.assertEqual(dl.part, False)
 
 
-class TestDownloaderBase(unittest.TestCase):
+class TestHTTPDownloaderAria2c(unittest.TestCase):
+    """Tests for the aria2c backend option of HttpDownloader."""
 
+    def setUp(self):
+        config.clear()
+        self.job = FakeJob()
+        self.dl = downloader.find("http")(self.job)
+        # Enable a fake aria2c path so _can_use_aria2c can return True.
+        self.dl._aria2c = "aria2c"
+
+    def tearDown(self):
+        config.clear()
+
+    # ------------------------------------------------------------------
+    # _can_use_aria2c eligibility checks
+    # ------------------------------------------------------------------
+
+    def _can(self, **kwdict):
+        return self.dl._can_use_aria2c(kwdict)
+
+    def _prepare_aria2c_download(self, tmpdir, extension="jpg", name="aria2c"):
+        config.set((), "base-directory", tmpdir)
+        job = FakeJob()
+        dl = downloader.find("http")(job)
+        dl._aria2c = "aria2c"
+
+        kwdict = {
+            "category"   : "test",
+            "subcategory": "test",
+            "filename"   : name,
+            "extension"  : extension,
+        }
+        pathfmt = job.pathfmt
+        pathfmt.set_directory(kwdict)
+        pathfmt.set_filename(kwdict)
+        pathfmt.build_path()
+
+        return dl, pathfmt
+
+    def test_aria2c_config_false_by_default(self):
+        dl = downloader.find("http")(self.job)
+        self.assertEqual(dl._aria2c, False)
+
+    def test_aria2c_config_true_becomes_string(self):
+        config.set(("downloader", "http"), "aria2c", True)
+        dl = downloader.find("http")(self.job)
+        self.assertEqual(dl._aria2c, "aria2c")
+
+    def test_aria2c_config_custom_path(self):
+        config.set(("downloader", "http"), "aria2c", "/usr/local/bin/aria2c")
+        dl = downloader.find("http")(self.job)
+        self.assertEqual(dl._aria2c, "/usr/local/bin/aria2c")
+
+    def test_can_use_aria2c_simple_get(self):
+        self.assertTrue(self._can(extension="jpg"))
+
+    def test_can_use_aria2c_no_aria2c(self):
+        self.dl._aria2c = False
+        self.assertFalse(self._can(extension="jpg"))
+
+    def test_can_use_aria2c_non_get_method(self):
+        self.assertFalse(self._can(extension="jpg", _http_method="POST"))
+
+    def test_can_use_aria2c_with_data(self):
+        self.assertFalse(self._can(extension="jpg", _http_data=b"body"))
+
+    def test_can_use_aria2c_with_validate(self):
+        self.assertFalse(self._can(extension="jpg",
+                                   _http_validate=lambda r: True))
+
+    def test_can_use_aria2c_with_retry(self):
+        self.assertFalse(self._can(extension="jpg",
+                                   _http_retry=lambda r: False))
+
+    def test_can_use_aria2c_with_expected_status(self):
+        self.assertFalse(self._can(extension="jpg",
+                                   _http_expected_status=(202,)))
+
+    def test_can_use_aria2c_with_segmented(self):
+        self.assertFalse(self._can(extension="jpg", _http_segmented=True))
+
+    def test_can_use_aria2c_metadata_enabled(self):
+        self.dl.metadata = "http_headers"
+        self.assertFalse(self._can(extension="jpg"))
+
+    def test_can_use_aria2c_no_extension(self):
+        # When extension is unknown, MIME type must come from the response
+        self.assertFalse(self._can(extension=""))
+        self.assertFalse(self._can())
+
+    # ------------------------------------------------------------------
+    # Fallback when aria2c binary is not found
+    # ------------------------------------------------------------------
+
+    def test_aria2c_fallback_on_not_found(self):
+        """FileNotFoundError from subprocess falls back to built-in."""
+        # Spin up a tiny server returning a known payload
+        payload = DATA["jpg"]
+        addr_holder = []
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", len(payload))
+                self.end_headers()
+                self.wfile.write(payload)
+            def log_message(self, *a):
+                pass
+
+        srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        addr_holder.append(srv.server_address)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        host, port = addr_holder[0]
+        url = f"http://{host}:{port}/img.jpg"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.set((), "base-directory", tmpdir)
+            job = FakeJob()
+            dl = downloader.find("http")(job)
+            dl._aria2c = "/nonexistent/aria2c"
+
+            kwdict = {
+                "category"   : "test",
+                "subcategory": "test",
+                "filename"   : "fallback",
+                "extension"  : "jpg",
+            }
+            pf = job.pathfmt
+            pf.set_directory(kwdict)
+            pf.set_filename(kwdict)
+            pf.build_path()
+
+            with self.assertLogs(dl.log, "WARNING"):
+                result = dl.download(url, pf)
+
+        self.assertTrue(result)
+        self.assertIsNone(dl._aria2c,
+                          "aria2c should be disabled after fallback")
+
+    @patch.object(http_downloader.subprocess, "run")
+    def test_aria2c_forwards_matching_cookies_and_timeout(self, run):
+        captured = {}
+
+        def side_effect(cmd, capture_output):
+            captured["cmd"] = cmd
+            outdir = next(arg[6:] for arg in cmd if arg.startswith("--dir="))
+            outfile = next(arg[6:] for arg in cmd if arg.startswith("--out="))
+            os.makedirs(outdir, exist_ok=True)
+            with open(os.path.join(outdir, outfile), "wb") as fp:
+                fp.write(DATA["jpg"])
+            return Mock(returncode=0, stderr=b"")
+
+        run.side_effect = side_effect
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dl, pathfmt = self._prepare_aria2c_download(tmpdir)
+            dl.timeout = 7
+            dl.session.cookies.set("good", "1", domain="example.org", path="/")
+            dl.session.cookies.set("bad", "2", domain="invalid.example",
+                                   path="/")
+
+            result = dl.download("https://example.org/file.jpg", pathfmt)
+
+        self.assertTrue(result)
+        headers = [
+            arg for arg in captured["cmd"]
+            if arg.startswith("--header=")
+        ]
+        self.assertIn("--header=Cookie: good=1", headers)
+        self.assertNotIn("--header=Cookie: bad=2", headers)
+        self.assertIn("--split=16", captured["cmd"])
+        self.assertIn("--max-connection-per-server=16", captured["cmd"])
+        self.assertIn("--min-split-size=1M", captured["cmd"])
+        self.assertIn("--file-allocation=none", captured["cmd"])
+        self.assertIn("--timeout=7", captured["cmd"])
+        self.assertIn("--connect-timeout=7", captured["cmd"])
+
+    @patch.object(http_downloader.subprocess, "run")
+    def test_aria2c_removes_invalid_html_download(self, run):
+        def side_effect(cmd, capture_output):
+            outdir = next(arg[6:] for arg in cmd if arg.startswith("--dir="))
+            outfile = next(arg[6:] for arg in cmd if arg.startswith("--out="))
+            os.makedirs(outdir, exist_ok=True)
+            with open(os.path.join(outdir, outfile), "wb") as fp:
+                fp.write(DATA["html"])
+            return Mock(returncode=0, stderr=b"")
+
+        run.side_effect = side_effect
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dl, pathfmt = self._prepare_aria2c_download(
+                tmpdir, name="invalid_html_as_jpg")
+            partpath = pathfmt.realpath + ".part"
+
+            with self.assertLogs(dl.log, "WARNING") as log_info:
+                result = dl.download("https://example.org/file.jpg", pathfmt)
+
+            self.assertFalse(result)
+            self.assertEqual(log_info.output[-1],
+                             "WARNING:downloader.http:HTML response")
+            self.assertFalse(os.path.exists(partpath))
+            self.assertEqual(pathfmt.temppath, "")
+
+
+class TestDownloaderBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
This pull request introduces optional support for using `aria2c` as a high-throughput HTTP downloader backend in *gallery-dl*. The changes add configuration options, documentation, and implementation logic to enable `aria2c` for eligible downloads, while maintaining automatic fallback to the built-in downloader for unsupported cases. The documentation is updated to explain usage, limitations, and tuning options.

New downloader backend and configuration:

* Added `aria2c` support as an optional HTTP downloader backend, including configuration options (`downloader.http.aria2c`) and integration logic in `gallery_dl/downloader/http.py`. Downloads are routed to `aria2c` when eligible, with automatic fallback for unsupported cases. [[1]](diffhunk://#diff-0e51669ff0f6fff20a0f359fb169c757ab7674bd0d38341a716f55e5e257bcfeR11-R22) [[2]](diffhunk://#diff-0e51669ff0f6fff20a0f359fb169c757ab7674bd0d38341a716f55e5e257bcfeR104-R112) [[3]](diffhunk://#diff-0e51669ff0f6fff20a0f359fb169c757ab7674bd0d38341a716f55e5e257bcfeR124-R369)
* Updated example configuration files (`docs/gallery-dl-example.conf`, `docs/gallery-dl.conf`) to demonstrate and document the new `aria2c` option. [[1]](diffhunk://#diff-140c787eb344149d557ba5ccdc76e4c747b277d877a3f6da264d9452ea5ebd6cR346-R352) [[2]](diffhunk://#diff-5241129d8d543d795389f7bc2e99038c47546c1091e58f26451be7d33b377229R1276)

Documentation updates:

* Expanded `README.rst` to describe `aria2c` usage, configuration, limitations, and added a reference link. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR28) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR302-R333) [[3]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR507)
* Added detailed documentation for `downloader.http.aria2c` in `docs/configuration.rst`, including quick start, behavior, limitations, and fallback mechanisms.

Testing:

* Updated `test/test_downloader.py` to check the new `aria2c` configuration attribute in the HTTP downloader. [[1]](diffhunk://#diff-bc220f419e4499a0456a049e4836c442baecbb7ffbaea2de0d9cb094902b69fdR25) [[2]](diffhunk://#diff-bc220f419e4499a0456a049e4836c442baecbb7ffbaea2de0d9cb094902b69fdR138)