### PR TITLE
[pixiv] implement fast skip for novel bookmarks

### DIFF
--- a/gallery_dl/extractor/pixiv.py
+++ b/gallery_dl/extractor/pixiv.py
@@ -396,6 +396,129 @@ class PixivExtractor(Extractor):
         return {}
 
 
+class PixivBookmarkExtractorMixin():
+    """Cursor-aware fast-skip support for Pixiv bookmark feeds"""
+    bookmark_items_key = None
+
+    def _init(self):
+        super()._init()
+
+        if self._bookmark_fast_skip_enabled():
+            limit = self._bookmark_range_limit()
+            if limit and (not self.max_posts or limit < self.max_posts):
+                self.max_posts = limit
+
+    def _bookmark_fast_skip_enabled(self):
+        return True
+
+    def _bookmark_state_init(self):
+        self._bookmark_buffer = []
+        self._bookmark_params = None
+
+    def _bookmark_range_limit(self):
+        rangespec = self.config2("file-range", "image-range")
+        if not rangespec:
+            return None
+        try:
+            ranges = util.predicate_range_parse(rangespec)
+        except ValueError:
+            return None
+
+        if len(ranges) != 1:
+            return None
+
+        range_ = ranges[0]
+        lower = range_.start
+        upper = range_.stop - 1
+        if range_.step != 1 or upper < lower:
+            return None
+
+        return upper - lower + 1
+
+    def _bookmark_base_params(self):
+        params = self._bookmark_list_params()
+        cursor = self.query.get("max_bookmark_id")
+        if cursor is not None:
+            params["max_bookmark_id"] = str(cursor)
+        return params
+
+    def _bookmark_page(self, params):
+        """Return one bookmark listing page"""
+
+    def _bookmark_list_params(self):
+        """Return base listing parameters"""
+
+    @staticmethod
+    def _bookmark_next_params(data):
+        next_url = data.get("next_url")
+        if not next_url:
+            return None
+        return text.parse_query(next_url.rpartition("?")[2])
+
+    def _bookmark_iter(self):
+        if self._bookmark_params is None:
+            self._bookmark_params = self._bookmark_base_params()
+
+        while True:
+            if self._bookmark_buffer:
+                items = self._bookmark_buffer
+                self._bookmark_buffer = []
+                yield from items
+                continue
+
+            if not self._bookmark_params:
+                return
+
+            data = self._bookmark_page(self._bookmark_params)
+            self._bookmark_params = self._bookmark_next_params(data)
+            yield from data[self.bookmark_items_key]
+
+    def skip_files(self, num):
+        if not self._bookmark_fast_skip_enabled():
+            return 0
+
+        target = num - 1
+        if target <= 0:
+            return 0
+
+        if self._bookmark_params is None:
+            self._bookmark_params = self._bookmark_base_params()
+
+        skipped = 0
+        pages = 0
+
+        while skipped < target:
+            if self._bookmark_buffer:
+                count = min(target - skipped, len(self._bookmark_buffer))
+                del self._bookmark_buffer[:count]
+                skipped += count
+                continue
+
+            if not self._bookmark_params:
+                break
+
+            data = self._bookmark_page(self._bookmark_params)
+            items = list(data[self.bookmark_items_key])
+            self._bookmark_params = self._bookmark_next_params(data)
+            pages += 1
+
+            if not items:
+                break
+
+            remaining = target - skipped
+            if remaining < len(items):
+                self._bookmark_buffer = items[remaining:]
+                skipped += remaining
+                break
+
+            skipped += len(items)
+
+        if skipped:
+            self.log.debug("Fast-skipped %s bookmark items in %s page(s)",
+                           skipped, pages)
+        return skipped
+
+
 class PixivUserExtractor(Dispatch, PixivExtractor):
     """Extractor for a pixiv user profile"""
     pattern = (BASE_PATTERN + r"/(?:"
@@ -1088,23 +1211,41 @@ class PixivNovelSeriesExtractor(PixivNovelExtractor):
         return self.api.novel_series(self.novel_id)
 
 
-class PixivNovelBookmarkExtractor(PixivNovelExtractor):
+class PixivNovelBookmarkExtractor(PixivBookmarkExtractorMixin,
+                                  PixivNovelExtractor):
     """Extractor for bookmarked pixiv novels"""
+    bookmark_items_key = "novels"
     subcategory = "bookmark"
     pattern = (USER_PATTERN + r"/bookmarks/novels"
                r"(?:/([^/?#]+))?(?:/?\?([^#]+))?")
     example = "https://www.pixiv.net/en/users/12345/bookmarks/novels"
 
-    def novels(self):
-        user_id, tag, query = self.groups
-        tag = text.unquote(tag) if tag else None
+    def __init__(self, match):
+        PixivNovelExtractor.__init__(self, match)
+        self.user_id, self.tag, query = self.groups
+        self.query = text.parse_query(query)
+        self._bookmark_state_init()
 
-        if text.parse_query(query).get("rest") == "hide":
+    def _bookmark_list_params(self):
+        tag = text.unquote(self.tag) if self.tag else None
+
+        if self.query.get("rest") == "hide":
             restrict = "private"
         else:
             restrict = "public"
 
-        return self.api.user_bookmarks_novel(user_id, tag, restrict)
+        return {"user_id": self.user_id, "tag": tag, "restrict": restrict}
+
+    def _bookmark_page(self, params):
+        return self.api.user_bookmarks_novel_page(params)
+
+    def _bookmark_fast_skip_enabled(self):
+        # Covers and embeds can emit additional files per bookmarked novel,
+        # so file-range skipping must fall back to normal walking.
+        return not (self.config("covers") or self.config("embeds"))
+
+    def novels(self):
+        return self._bookmark_iter()
 
 
 ###############################################################################
@@ -1263,6 +1404,10 @@ class PixivAppAPI():
         """Return novels bookmarked by a user"""
         params = {"user_id": user_id, "tag": tag, "restrict": restrict}
         return self._pagination("/v1/user/bookmarks/novel", params, "novels")
+
+    def user_bookmarks_novel_page(self, params):
+        """Return one page of bookmarked novels"""
+        return self._call("/v1/user/bookmarks/novel", params)
 
     def user_bookmark_tags_illust(self, user_id, restrict="public"):
         """Return bookmark tags defined by a user"""

--- a/test/test_pixiv.py
+++ b/test/test_pixiv.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2026 Mike Fährmann
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+import itertools
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from gallery_dl.extractor.pixiv import PixivBookmarkExtractorMixin  # noqa E402
+
+
+class _DummyLog():
+    def __init__(self):
+        self.messages = []
+
+    def debug(self, msg, *args):
+        self.messages.append(msg % args if args else msg)
+
+
+class _DummyBookmarkBase():
+    def __init__(self, config):
+        self._config = config
+        self.log = _DummyLog()
+        self.max_posts = 0
+
+    def _init(self):
+        self.max_posts = self.config("max-posts", 0)
+
+    def config(self, key, default=None):
+        return self._config.get(key, default)
+
+    def config2(self, key, key2, default=None):
+        if key in self._config:
+            return self._config[key]
+        return self._config.get(key2, default)
+
+
+class DummyBookmarkExtractor(PixivBookmarkExtractorMixin, _DummyBookmarkBase):
+    bookmark_items_key = "novels"
+
+    def __init__(self, pages, config=None, query=None):
+        _DummyBookmarkBase.__init__(self, config or {})
+        self.query = query or {}
+        self.pages = {
+            ((self._params_key(params) if hasattr(params, "items")
+              else params)): data
+            for params, data in pages.items()
+        }
+        self.calls = []
+        self._bookmark_state_init()
+
+    @staticmethod
+    def _params_key(params):
+        return tuple(sorted(
+            (key, str(value))
+            for key, value in params.items()
+            if value is not None
+        ))
+
+    def _bookmark_list_params(self):
+        return {"user_id": "1", "tag": None, "restrict": "private"}
+
+    def _bookmark_page(self, params):
+        key = self._params_key(params)
+        self.calls.append(key)
+        return self.pages[key]
+
+    def _bookmark_fast_skip_enabled(self):
+        return not (self.config("covers") or self.config("embeds"))
+
+
+class TestPixivBookmarkSkip(unittest.TestCase):
+    def test_skip_files_uses_cursor_pages_and_buffers_remainder(self):
+        first = {
+            "user_id": "1",
+            "restrict": "private",
+        }
+        second = {
+            "user_id": "1",
+            "restrict": "private",
+            "max_bookmark_id": "99",
+        }
+        pages = {
+            tuple(sorted(first.items())): {
+                "novels": [{"id": num} for num in range(30)],
+                "next_url": ("https://app-api.pixiv.net/v1/user/bookmarks/"
+                             "novel?user_id=1&restrict=private"
+                             "&max_bookmark_id=99"),
+            },
+            tuple(sorted(second.items())): {
+                "novels": [{"id": num} for num in range(30, 60)],
+                "next_url": ("https://app-api.pixiv.net/v1/user/bookmarks/"
+                             "novel?user_id=1&restrict=private"
+                             "&max_bookmark_id=49"),
+            },
+        }
+
+        extr = DummyBookmarkExtractor(pages, config={"file-range": "51-55"})
+        extr._init()
+
+        self.assertEqual(extr.skip_files(51), 50)
+        self.assertEqual(len(extr.calls), 2)
+        self.assertIn("Fast-skipped 50 bookmark items in 2 page(s)",
+                      extr.log.messages)
+
+        items = list(itertools.islice(extr._bookmark_iter(), 5))
+        self.assertEqual([item["id"] for item in items], [50, 51, 52, 53, 54])
+        self.assertEqual(len(extr.calls), 2)
+
+    def test_range_limit_caps_max_posts_for_contiguous_ranges(self):
+        extr = DummyBookmarkExtractor({}, config={"file-range": "51-55"})
+        extr._init()
+        self.assertEqual(extr.max_posts, 5)
+
+    def test_range_limit_accepts_legacy_image_range_alias(self):
+        extr = DummyBookmarkExtractor({}, config={"image-range": "51-55"})
+        extr._init()
+        self.assertEqual(extr.max_posts, 5)
+
+    def test_range_limit_ignores_sparse_ranges(self):
+        extr = DummyBookmarkExtractor(
+            {}, config={"file-range": "51,53,55", "max-posts": 9})
+        extr._init()
+        self.assertEqual(extr.max_posts, 9)
+
+    def test_range_limit_disabled_when_covers_are_enabled(self):
+        extr = DummyBookmarkExtractor(
+            {}, config={"file-range": "51-55", "max-posts": 9, "covers": True})
+        extr._init()
+        self.assertEqual(extr.max_posts, 9)
+
+    def test_skip_files_disabled_when_embeds_are_enabled(self):
+        first = {
+            "user_id": "1",
+            "restrict": "private",
+        }
+        pages = {
+            tuple(sorted(first.items())): {
+                "novels": [{"id": num} for num in range(30)],
+                "next_url": None,
+            },
+        }
+
+        extr = DummyBookmarkExtractor(
+            pages, config={"file-range": "51-55", "embeds": True})
+        extr._init()
+
+        self.assertEqual(extr.skip_files(51), 0)
+        self.assertEqual(extr.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Pixiv novel bookmark extraction currently inherits the default no-op
`skip_files()`, so `--range` still walks earlier bookmarks one by one before
reaching the requested slice.

This patch adds cursor-aware file skipping for Pixiv novel bookmarks using the
API's `next_url` / `max_bookmark_id` pagination.

## Changes

- add cursor-aware `skip_files()` support for `PixivNovelBookmarkExtractor`
- fetch bookmark listing pages directly while skipping
- buffer the remainder of a partially skipped page so extraction resumes
  without refetching the landing page
- add a single-page bookmark API helper for novel bookmarks
- cap contiguous `file-range` selections, with legacy `image-range` fallback,
  to the requested slice length after fast skip
- fall back to normal range walking when `covers` or `embeds` are enabled,
  since those options can emit multiple files per bookmarked novel

## Testing

- `python3 -m flake8 gallery_dl/extractor/pixiv.py test/test_pixiv.py`
- `/usr/local/bin/python3 -m unittest test.test_job test.test_pixiv`

The added tests cover:

- skipping across cursor-paginated bookmark pages
- reusing the buffered remainder after a partial skip
- contiguous range capping
- legacy `image-range` alias support

Additionally, I validated the repaired branch against real Pixiv novel
bookmark ranges:

- public novels: upstream baseline and patched branch produced the same files
  for `--range 11-15`
- hidden novels: patched branch successfully fast-skipped onto `--range 31-35`
  on the private bookmark feed
- public novels with `covers=true`: upstream baseline and patched branch
  produced the same files for `--range 3-6`, with no fast-skip applied
