### PR TITLE
Fix: TwitterFollowingExtractor and TwitterFollowersExtractor missing api attribute

### DIFF
--- a/gallery_dl/extractor/twitter.py
+++ b/gallery_dl/extractor/twitter.py
@@ -1030,8 +1030,9 @@ class TwitterFollowingExtractor(TwitterExtractor):
     example = "https://x.com/USER/following"
 
     def items(self):
+        self.api = TwitterAPI(self)
         self.login()
-        return self._users_result(TwitterAPI(self).user_following(self.user))
+        return self._users_result(self.api.user_following(self.user))
 
 
 class TwitterFollowersExtractor(TwitterExtractor):
@@ -1041,8 +1042,9 @@ class TwitterFollowersExtractor(TwitterExtractor):
     example = "https://x.com/USER/followers"
 
     def items(self):
+        self.api = TwitterAPI(self)
         self.login()
-        return self._users_result(TwitterAPI(self).user_followers(self.user))
+        return self._users_result(self.api.user_followers(self.user))
 
 
 class TwitterCommunityExtractor(TwitterExtractor):


### PR DESCRIPTION
## Summary

When using the following/followers extractors, the code raises an AttributeError because self.api was not initialized.

## Root Cause

In TwitterFollowingExtractor.items() and TwitterFollowersExtractor.items(), self.login() is called but self.api was not initialized before. The base TwitterExtractor.items() method sets self.api = TwitterAPI(self) before calling self.login(), but these extractors override items() without following this pattern.

## Fix

Add self.api = TwitterAPI(self) before self.login() in both extractors, and use self.api for the API calls instead of creating a new TwitterAPI(self) instance each time.

This matches the pattern used by other Twitter extractors in the base class.

## Changes

- gallery_dl/extractor/twitter.py:
  - TwitterFollowingExtractor.items(): Initialize self.api before self.login()
  - TwitterFollowersExtractor.items(): Initialize self.api before self.login()

Fixes #9271