### PR TITLE
Update tapas.py: fix unescaping of ampersands in comic URLs.

### DIFF
--- a/gallery_dl/extractor/tapas.py
+++ b/gallery_dl/extractor/tapas.py
@@ -98,7 +98,7 @@ class TapasEpisodeExtractor(TapasExtractor):
             episode["num"] = 1
             episode["extension"] = "html"
             yield Message.Url, "text:" + content, episode
-            
+
         else:  # comic
             for episode["num"], url in enumerate(text.extract_iter(
                     html, 'data-src="', '"'), 1):


### PR DESCRIPTION
The existing text.unescape(url) call was not correctly handling encoded ampersands in the
Tapas data-src attributes, leading to broken URLs. Replacing it with a manual .replace('&amp;', '&')
fixes the issue and allows images to download correctly.