### PR TITLE
[instagram] expose story item audience metadata

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -329,6 +329,8 @@ class InstagramExtractor(Extractor):
                 media["expires"] = self.parse_timestamp(item["expiring_at"])
             if "subscription_media_visibility" in item:
                 media["subscription"] = item["subscription_media_visibility"]
+            if "audience" in item:
+                media["audience"] = item["audience"]
 
             self._extract_tagged_users(item, media)
             files.append(media)


### PR DESCRIPTION
Instagram marks close friends stories with:
`"audience": "besties"`
Exposing that raw metadata makes it possible to distinguish close friends
stories from regular stories in config