### PR TITLE
[instagram] handle missing music_info and skip invalid audio URLs

### DIFF
--- a/gallery_dl/extractor/instagram.py
+++ b/gallery_dl/extractor/instagram.py
@@ -351,8 +351,9 @@ class InstagramExtractor(Extractor):
                     if audio["audio_url"]:
                         audio["num"] = num
                         files.append(audio)
-                    for key in ("audio_title", "audio_artist", "audio_username",
-                                "audio_duration", "audio_timestamps"):
+                    for key in ("audio_title", "audio_artist",
+                                "audio_username", "audio_duration",
+                                "audio_timestamps"):
                         data[key] = audio[key]
             except Exception as exc:
                 self.log.traceback(exc)


### PR DESCRIPTION
I encountered two related failures while processing Instagram REST responses:

`_parse_post_rest()` could fail when `music_metadata` was present but `music_info` was null, or when `music_asset_info` was missing:

`TypeError: 'NoneType' object is not subscriptable`

An invalid audio URL value could still be forwarded to the downloader:

```
[download][error] ':' URLs are not supported/enabled
[download][error] Failed to download
```

Tested locally, everything seems to be working. Was able to continue the download.