### PR TITLE
[snapchat] add support

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -1045,6 +1045,12 @@ Consider all listed sites to potentially be NSFW.
     <td>Albums, individual Images, Images from Users and Folders</td>
     <td><a href="https://github.com/mikf/gallery-dl#oauth">OAuth</a></td>
 </tr>
+<tr id="snapchat" title="snapchat">
+    <td>Snapchat</td>
+    <td>https://www.snapchat.com/</td>
+    <td>Avatars, Spotlights, Stories, Users</td>
+    <td></td>
+</tr>
 <tr id="soundgasm" title="soundgasm">
     <td>Soundgasm</td>
     <td>https://soundgasm.net/</td>

--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -1048,7 +1048,7 @@ Consider all listed sites to potentially be NSFW.
 <tr id="snapchat" title="snapchat">
     <td>Snapchat</td>
     <td>https://www.snapchat.com/</td>
-    <td>Avatars, Spotlights, Stories, Users</td>
+    <td>Avatars, Spotlights, Stories, User Profiles</td>
     <td></td>
 </tr>
 <tr id="soundgasm" title="soundgasm">

--- a/gallery_dl/extractor/__init__.py
+++ b/gallery_dl/extractor/__init__.py
@@ -199,6 +199,7 @@ modules = [
     "slickpic",
     "slideshare",
     "smugmug",
+    "snapchat",
     "soundgasm",
     "speakerdeck",
     "steamgriddb",

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -11,7 +11,8 @@ from .. import text, util
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?snapchat\.com"
 ALPHANUMERIC = r"[^/?#]+"
-USER_PATTERN = BASE_PATTERN + rf"/(?:@|add/)({ALPHANUMERIC})"
+USER = rf"(?:@|add/)({ALPHANUMERIC})"
+USER_PATTERN = BASE_PATTERN + r"/" + USER
 
 
 class SnapchatExtractor(Extractor):
@@ -139,8 +140,8 @@ class SnapchatStoryExtractor(SnapchatExtractor):
     # https://www.snapchat.com/@snackattackshow/
     # PnJFM8uuTRWo90OsrEH5pwAAgeGZvd2RrZGxxAZ1I2NonAZ1I2NmfAAAAAA.
     pattern = USER_PATTERN + r"/(?:highlight/)?[^/?#]{20,}"
-    example = "https://www.snapchat.com/@username/highlight/"
-    "c3050cba-2f43-4e06-8ac4-d79069bac22f"
+    example = "https://www.snapchat.com/@username/highlight/" + \
+        "c3050cba-2f43-4e06-8ac4-d79069bac22f"
 
     def items(self):
         next_data = self._extract_next_data(self.url)
@@ -166,9 +167,9 @@ class SnapchatStoryExtractor(SnapchatExtractor):
 class SnapchatSpotlightExtractor(SnapchatExtractor):
     """Extracts an individual spotlight post"""
     subcategory = "spotlight"
-    pattern = BASE_PATTERN + rf"/(?:@{ALPHANUMERIC}/)?spotlight/{ALPHANUMERIC}"
-    example = "https://www.snapchat.com/spotlight/"
-    "W7_EDlXWTBiXAEEniNoMPwAAYdGFzb3FpYXVuAZqDMm6sAZqDMm6VAAAAAQ"
+    pattern = BASE_PATTERN + rf"/(?:{USER})?spotlight/{ALPHANUMERIC}"
+    example = "https://www.snapchat.com/spotlight/" + \
+        "W7_EDlXWTBiXAEEniNoMPwAAYdGFzb3FpYXVuAZqDMm6sAZqDMm6VAAAAAQ"
 
     def items(self):
         next_data = self._extract_next_data(self.url)

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -241,7 +241,7 @@ class SnapchatSpotlightsExtractor(SnapchatLimitedSupportExtractor):
     user"""
     subcategory = "spotlights"
     pattern = USER_PATTERN + r"/spotlights"
-    example = "https://www.snapchat.com/@username/spotlight"
+    example = "https://www.snapchat.com/@username/spotlights"
 
     def items(self):
         user = self.groups[0]

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -10,7 +10,7 @@ from .common import Extractor, Message
 from .. import text
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?snapchat\.com"
-USER = r"(?:@|add/)([^/?#]+)"
+USER = r"(?:@|add/)([^/\?#]+)"
 USER_PATTERN = BASE_PATTERN + r"/" + USER
 
 
@@ -24,7 +24,7 @@ class SnapchatExtractor(Extractor):
     root = "https://www.snapchat.com"
     cookies_domain = ".snapchat.com"
 
-    def _extract_next_data(self, url):
+    def _request_next_data(self, url):
         html = self.request(url).text
         data = self._extract_nextdata(html)
         return data["props"]["pageProps"]
@@ -45,7 +45,7 @@ class SnapchatExtractor(Extractor):
             "type"     : "avatar",
             # Unfortunately, the file extension is non-standard.
             # We'll need to overwrite it.
-            "extension": "jpeg",
+            "extension": "jpg",
             "date"     : self.parse_timestamp(timestamp),
             "id"       : metadata["username"],
             "file_id"  : url.rpartition("/")[2].rpartition(".")[0],
@@ -92,7 +92,7 @@ class SnapchatExtractor(Extractor):
             "type"     : "image" if type == "0" else "video",
             # Unfortunately, the file extension is non-standard.
             # We'll need to overwrite it.
-            "extension": "jpeg" if type == "o" else "mp4",
+            "extension": "jpg" if type == "o" else "mp4",
             "date"     : self.parse_timestamp(timestamp),
             "id"       : id,
             "num"      : item["snapIndex"] + 1,
@@ -121,7 +121,7 @@ class SnapchatAvatarExtractor(SnapchatExtractor):
     def items(self):
         user = self.groups[0]
         profile_url = f"{self.root}/@{user}"
-        next_data = self._extract_next_data(profile_url)
+        next_data = self._request_next_data(profile_url)
         next_data["user"] = user
 
         [avatar_url, next_data] = self._extract_avatar(next_data)
@@ -136,12 +136,12 @@ class SnapchatStoryExtractor(SnapchatExtractor):
     # one. It is used to match against "timed" stories such as this one:
     # https://www.snapchat.com/@snackattackshow/
     # PnJFM8uuTRWo90OsrEH5pwAAgeGZvd2RrZGxxAZ1I2NonAZ1I2NmfAAAAAA.
-    pattern = USER_PATTERN + r"/(?:highlight/)?[^/?#]{20,}"
+    pattern = USER_PATTERN + r"/(?:highlight/)?[^/\?#]{20,}"
     example = "https://www.snapchat.com/@username/highlight/" + \
         "c3050cba-2f43-4e06-8ac4-d79069bac22f"
 
     def items(self):
-        next_data = self._extract_next_data(self.url)
+        next_data = self._request_next_data(self.url)
         story_data = self._extract_story(next_data)
         if "publicUserProfile" in next_data:
             story_data["user"] = next_data["publicUserProfile"]["username"]
@@ -164,12 +164,12 @@ class SnapchatStoryExtractor(SnapchatExtractor):
 class SnapchatSpotlightExtractor(SnapchatExtractor):
     """Extracts an individual spotlight post"""
     subcategory = "spotlight"
-    pattern = BASE_PATTERN + rf"/(?:{USER})?spotlight/[^/?#]+"
+    pattern = BASE_PATTERN + rf"/(?:{USER}/)?spotlight/[^/\?#]+"
     example = "https://www.snapchat.com/spotlight/" + \
         "W7_EDlXWTBiXAEEniNoMPwAAYdGFzb3FpYXVuAZqDMm6sAZqDMm6VAAAAAQ"
 
     def items(self):
-        next_data = self._extract_next_data(self.url)
+        next_data = self._request_next_data(self.url)
         next_data = self._extract_spotlight_feed(next_data)
         spotlight_data = next_data[0]["story"].copy()
         spotlight_data["metadata"] = next_data[0]["metadata"].copy()
@@ -214,7 +214,7 @@ class SnapchatStoriesExtractor(SnapchatLimitedSupportExtractor):
     def items(self):
         user = self.groups[0]
         profile_url = f"{self.root}/@{user}"
-        next_data = self._extract_next_data(profile_url)
+        next_data = self._request_next_data(profile_url)
         next_data["user"] = user
 
         yield Message.Directory, "", next_data
@@ -243,7 +243,7 @@ class SnapchatSpotlightsExtractor(SnapchatLimitedSupportExtractor):
     def items(self):
         user = self.groups[0]
         profile_url = f"{self.root}/@{user}"
-        next_data = self._extract_next_data(profile_url)
+        next_data = self._request_next_data(profile_url)
         next_data["user"] = user
 
         yield Message.Directory, "", next_data
@@ -266,13 +266,13 @@ class SnapchatSpotlightsExtractor(SnapchatLimitedSupportExtractor):
 class SnapchatUserExtractor(SnapchatLimitedSupportExtractor):
     """Extractor for a Snapchat user profile"""
     subcategory = "user"
-    pattern = USER_PATTERN
+    pattern = USER_PATTERN + r"$"
     example = "https://www.snapchat.com/@username"
 
     def items(self):
         user = self.groups[0]
         profile_url = f"{self.root}/@{user}"
-        next_data = self._extract_next_data(profile_url)
+        next_data = self._request_next_data(profile_url)
         next_data["user"] = user
 
         yield Message.Directory, "", next_data

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -197,9 +197,12 @@ class SnapchatLimitedSupportExtractor(SnapchatExtractor):
 
     def _init(self):
         if not SnapchatLimitedSupportExtractor._user_has_been_alerted:
+            subcategory = self.subcategory
+            if subcategory == "user":
+                subcategory += "s"
             self.log.warning("Be aware that support for Snapchat %s is "
                              "limited, you may not be able to download every "
-                             "post!", self.subcategory)
+                             "post!", subcategory)
             SnapchatLimitedSupportExtractor._user_has_been_alerted = True
 
 
@@ -264,7 +267,7 @@ class SnapchatSpotlightsExtractor(SnapchatLimitedSupportExtractor):
 
 class SnapchatUserExtractor(SnapchatLimitedSupportExtractor):
     """Extractor for a Snapchat user profile"""
-    subcategory = "users"
+    subcategory = "user"
     pattern = USER_PATTERN
     example = "https://www.snapchat.com/@username"
 

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+"""Extractors for https://www.snapchat.com/"""
+
+from .common import Extractor, Message
+from .. import text, util
+
+BASE_PATTERN = r"(?:https?://)?(?:www\.)?snapchat\.com"
+ALPHANUMERIC = r"[^/?#]+"
+USER_PATTERN = BASE_PATTERN + rf"/(?:@|add/)({ALPHANUMERIC})"
+
+
+class SnapchatExtractor(Extractor):
+    """Base class for Snapchat extractors"""
+    category = "snapchat"
+    directory_fmt = ("{category}", "{user}")
+    filename_fmt = (
+        "{date} {id}{num:?_//>02} {title[b:150]}{file_id:? [/]/}.{extension}")
+    archive_fmt = "{date}_{id}_{num}_{file_id}"
+    root = "https://www.snapchat.com"
+    cookies_domain = ".snapchat.com"
+
+    def _extract_next_data(self, url):
+        html = self.request(url).text
+        data = text.extr(html,
+                         '<script id="__NEXT_DATA__" type="application/json">',
+                         '</script>')
+        return util.json_loads(data)["props"]["pageProps"]
+
+    def _extract_avatar(self, next_data):
+        metadata = next_data["userProfile"]["publicProfileInfo"].copy()
+
+        url = metadata["profilePictureUrl"]
+        text.nameext_from_url(url, metadata)
+        try:
+            timestamp = metadata["lastUpdateTimestampMs"]["value"]
+        except (KeyError, TypeError):
+            timestamp = metadata["creationTimestampMs"]["value"]
+        # Ignore the milliseconds from the timestamp.
+        timestamp = timestamp[:-3]
+
+        metadata.update({
+            "type"     : "avatar",
+            # Unfortunately, the file extension is non-standard.
+            # We'll need to overwrite it.
+            "extension": "jpeg",
+            "date"     : self.parse_timestamp(timestamp),
+            "id"       : metadata["username"],
+            "file_id"  : url.rpartition("/")[2].rpartition(".")[0],
+            "num"      : 0,
+            "url"      : url,
+            "user"     : next_data["user"],
+        })
+
+        return [url, metadata]
+
+    def _extract_story_list(self, next_data):
+        return next_data["curatedHighlights"].copy()
+
+    def _extract_story(self, next_data):
+        if "highlight" in next_data:
+            return next_data["highlight"].copy()
+        return next_data["story"].copy()
+
+    def _extract_spotlight_list(self, next_data):
+        return next_data["spotlightHighlights"].copy()
+
+    def _extract_spotlight_feed(self, next_data):
+        return next_data["spotlightFeed"]["spotlightStories"].copy()
+
+    def _extract_post(self, data, item, default_title):
+        url = item["snapUrls"]["mediaUrl"]
+        text.nameext_from_url(url, data)
+        timestamp = item["timestampInSec"]["value"]
+        # 0: image, 1: video.
+        type = item["snapMediaType"]
+        try:
+            title = data["storyTitle"]["value"]
+        except (KeyError, TypeError):
+            title = default_title
+        id = item["snapId"]["value"]
+        if not id:
+            if "highlightId" in data:
+                id = data["highlightId"]["value"]
+            else:
+                id = data["storyId"]["value"]
+
+        data.update({
+            **item,
+            "type"     : "image" if type == "0" else "video",
+            # Unfortunately, the file extension is non-standard.
+            # We'll need to overwrite it.
+            "extension": "jpeg" if type == "o" else "mp4",
+            "date"     : self.parse_timestamp(timestamp),
+            "id"       : id,
+            "num"      : item["snapIndex"] + 1,
+            "title"    : title,
+            "file_id"  : url.partition("?")[0].rpartition("/")[2],
+            "url"      : url,
+        })
+
+        return [url, data]
+
+    def _extract_story_item(self, story_data, snap_item):
+        return self._extract_post(story_data, snap_item,
+                                  "Snapchat Story")
+
+    def _extract_spotlight_item(self, spotlight_data, snap_item):
+        return self._extract_post(spotlight_data, snap_item,
+                                  "Snapchat Spotlight")
+
+
+class SnapchatAvatarExtractor(SnapchatExtractor):
+    """Extracts a Snapchat user's avatar"""
+    subcategory = "avatar"
+    pattern = USER_PATTERN + r"/avatar"
+    example = "https://www.snapchat.com/@username/avatar"
+
+    def items(self):
+        user = self.groups[0]
+        profile_url = f"{self.root}/@{user}"
+        next_data = self._extract_next_data(profile_url)
+        next_data["user"] = user
+
+        [avatar_url, next_data] = self._extract_avatar(next_data)
+        yield Message.Directory, "", next_data
+        yield Message.Url, avatar_url, next_data
+
+
+class SnapchatStoryExtractor(SnapchatExtractor):
+    """Extracts an individual or timed story"""
+    subcategory = "story"
+    # The {20,} stops /stories and /spotlights URLs from matching with this
+    # one. It is used to match against "timed" stories such as this one:
+    # https://www.snapchat.com/@snackattackshow/
+    # PnJFM8uuTRWo90OsrEH5pwAAgeGZvd2RrZGxxAZ1I2NonAZ1I2NmfAAAAAA.
+    pattern = USER_PATTERN + r"/(?:highlight/)?[^/?#]{20,}"
+    example = "https://www.snapchat.com/@username/highlight/"
+    "c3050cba-2f43-4e06-8ac4-d79069bac22f"
+
+    def items(self):
+        next_data = self._extract_next_data(self.url)
+        story_data = self._extract_story(next_data)
+        if "publicUserProfile" in next_data:
+            story_data["user"] = next_data["publicUserProfile"]["username"]
+        else:
+            public_profile_info = next_data["userProfile"]["publicProfileInfo"]
+            story_data["user"] = public_profile_info["username"]
+
+        yield Message.Directory, "", story_data
+        for num, snap in enumerate(story_data["snapList"]):
+            try:
+                [url, story_item_data] = self._extract_story_item(
+                    story_data.copy(), snap)
+                yield Message.Url, url, story_item_data
+            except Exception as exc:
+                self.log.traceback(exc)
+                self.log.error("%s: Failed to extract story item %d (%s: %s)",
+                               self.url, num + 1, exc.__class__.__name__, exc)
+
+
+class SnapchatSpotlightExtractor(SnapchatExtractor):
+    """Extracts an individual spotlight post"""
+    subcategory = "spotlight"
+    pattern = BASE_PATTERN + rf"/(?:@{ALPHANUMERIC}/)?spotlight/{ALPHANUMERIC}"
+    example = "https://www.snapchat.com/spotlight/"
+    "W7_EDlXWTBiXAEEniNoMPwAAYdGFzb3FpYXVuAZqDMm6sAZqDMm6VAAAAAQ"
+
+    def items(self):
+        next_data = self._extract_next_data(self.url)
+        next_data = self._extract_spotlight_feed(next_data)
+        spotlight_data = next_data[0]["story"].copy()
+        spotlight_data["metadata"] = next_data[0]["metadata"].copy()
+        creator = spotlight_data["metadata"]["videoMetadata"]["creator"]
+        spotlight_data["user"] = creator["personCreator"]["username"]
+
+        yield Message.Directory, "", spotlight_data
+        for num, snap in enumerate(spotlight_data["snapList"]):
+            try:
+                [url, spotlight_item_data] = self._extract_spotlight_item(
+                    spotlight_data.copy(), snap)
+                yield Message.Url, url, spotlight_item_data
+            except Exception as exc:
+                self.log.traceback(exc)
+                self.log.error("%s: Failed to extract spotlight item %d (%s: "
+                               "%s)", self.url, num + 1,
+                               exc.__class__.__name__, exc)
+
+
+class SnapchatLimitedSupportExtractor(SnapchatExtractor):
+    """Notifies the user that this subcategory is only partially supported"""
+    _user_has_been_alerted = False
+
+    def _init(self):
+        if not SnapchatLimitedSupportExtractor._user_has_been_alerted:
+            self.log.warning("Be aware that support for Snapchat %s is "
+                             "limited, you may not be able to download every "
+                             "post!", self.subcategory)
+            SnapchatLimitedSupportExtractor._user_has_been_alerted = True
+
+
+class SnapchatStoriesExtractor(SnapchatLimitedSupportExtractor):
+    """Extracts every [known] story belonging to a single Snapchat
+    user"""
+    subcategory = "stories"
+    pattern = USER_PATTERN + r"/(?:stories|highlights)"
+    example = "https://www.snapchat.com/@username/stories"
+
+    def items(self):
+        user = self.groups[0]
+        profile_url = f"{self.root}/@{user}"
+        next_data = self._extract_next_data(profile_url)
+        next_data["user"] = user
+
+        yield Message.Directory, "", next_data
+        story_list = self._extract_story_list(next_data)
+        for num, story in enumerate(story_list):
+            for item_num, snap in enumerate(story["snapList"]):
+                try:
+                    [url, story_data] = self._extract_story_item(story.copy(),
+                                                                 snap)
+                    story_data["user"] = user
+                    yield Message.Url, url, story_data
+                except Exception as exc:
+                    self.log.traceback(exc)
+                    self.log.error("%s: Failed to extract item %d of story %d "
+                                   "(%s: %s)", self.url, item_num + 1, num + 1,
+                                   exc.__class__.__name__, exc)
+
+
+class SnapchatSpotlightsExtractor(SnapchatLimitedSupportExtractor):
+    """Extracts every [known] spotlight belonging to a single Snapchat
+    user"""
+    subcategory = "spotlights"
+    pattern = USER_PATTERN + r"/spotlights"
+    example = "https://www.snapchat.com/@username/spotlight"
+
+    def items(self):
+        user = self.groups[0]
+        profile_url = f"{self.root}/@{user}"
+        next_data = self._extract_next_data(profile_url)
+        next_data["user"] = user
+
+        yield Message.Directory, "", next_data
+        spotlight_list = self._extract_spotlight_list(next_data)
+        for num, spotlight in enumerate(spotlight_list):
+            for item_num, snap in enumerate(spotlight["snapList"]):
+                try:
+                    [url, spotlight_data] = self._extract_spotlight_item(
+                        spotlight.copy(), snap)
+                    spotlight_data["user"] = user
+                    yield Message.Url, url, spotlight_data
+                except Exception as exc:
+                    self.log.traceback(exc)
+                    self.log.error("%s: Failed to extract item %d of "
+                                   "spotlight %d (%s: %s)", self.url,
+                                   item_num + 1, num + 1,
+                                   exc.__class__.__name__, exc)
+
+
+class SnapchatUserExtractor(SnapchatLimitedSupportExtractor):
+    """Extractor for a Snapchat user profile"""
+    subcategory = "users"
+    pattern = USER_PATTERN
+    example = "https://www.snapchat.com/@username"
+
+    def items(self):
+        user = self.groups[0]
+        profile_url = f"{self.root}/@{user}"
+        next_data = self._extract_next_data(profile_url)
+        next_data["user"] = user
+
+        yield Message.Directory, "", next_data
+
+        # Avatar.
+        try:
+            [avatar_url, avatar_data] = self._extract_avatar(next_data)
+            yield Message.Url, avatar_url, avatar_data
+        except Exception as exc:
+            self.log.traceback(exc)
+            self.log.error("%s: Failed to extract avatar (%s: %s)",
+                           self.url, exc.__class__.__name__, exc)
+
+        # Stories.
+        story_list = self._extract_story_list(next_data)
+        for num, story in enumerate(story_list):
+            for item_num, snap in enumerate(story["snapList"]):
+                try:
+                    [url, story_data] = self._extract_story_item(story.copy(),
+                                                                 snap)
+                    story_data["user"] = user
+                    yield Message.Url, url, story_data
+                except Exception as exc:
+                    self.log.traceback(exc)
+                    self.log.error("%s: Failed to extract item %d of story "
+                                   "%d (%s: %s)", self.url, item_num + 1,
+                                   num + 1, exc.__class__.__name__, exc)
+
+        # Spotlight.
+        spotlight_list = self._extract_spotlight_list(next_data)
+        for num, spotlight in enumerate(spotlight_list):
+            for item_num, snap in enumerate(spotlight["snapList"]):
+                try:
+                    [url, spotlight_data] = self._extract_spotlight_item(
+                        spotlight.copy(), snap)
+                    spotlight_data["user"] = user
+                    yield Message.Url, url, spotlight_data
+                except Exception as exc:
+                    self.log.traceback(exc)
+                    self.log.error("%s: Failed to extract item %d of "
+                                   "spotlight %d (%s: %s)", self.url,
+                                   item_num + 1, num + 1,
+                                   exc.__class__.__name__, exc)

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -89,10 +89,10 @@ class SnapchatExtractor(Extractor):
 
         data.update({
             **item,
-            "type"     : "image" if type == "0" else "video",
+            "type"     : "image" if type == 0 else "video",
             # Unfortunately, the file extension is non-standard.
             # We'll need to overwrite it.
-            "extension": "jpg" if type == "o" else "mp4",
+            "extension": "jpg" if type == 0 else "mp4",
             "date"     : self.parse_timestamp(timestamp),
             "id"       : id,
             "num"      : item["snapIndex"] + 1,

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -75,7 +75,7 @@ class SnapchatExtractor(Extractor):
         text.nameext_from_url(url, data)
         timestamp = item["timestampInSec"]["value"]
         # 0: image, 1: video.
-        type = item["snapMediaType"]
+        media_type = item["snapMediaType"]
         try:
             title = data["storyTitle"]["value"]
         except (KeyError, TypeError):
@@ -89,10 +89,10 @@ class SnapchatExtractor(Extractor):
 
         data.update({
             **item,
-            "type"     : "image" if type == 0 else "video",
+            "type"     : "image" if media_type == 0 else "video",
             # Unfortunately, the file extension is non-standard.
             # We'll need to overwrite it.
-            "extension": "jpg" if type == 0 else "mp4",
+            "extension": "jpg" if media_type == 0 else "mp4",
             "date"     : self.parse_timestamp(timestamp),
             "id"       : id,
             "num"      : item["snapIndex"] + 1,

--- a/gallery_dl/extractor/snapchat.py
+++ b/gallery_dl/extractor/snapchat.py
@@ -7,11 +7,10 @@
 """Extractors for https://www.snapchat.com/"""
 
 from .common import Extractor, Message
-from .. import text, util
+from .. import text
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?snapchat\.com"
-ALPHANUMERIC = r"[^/?#]+"
-USER = rf"(?:@|add/)({ALPHANUMERIC})"
+USER = r"(?:@|add/)([^/?#]+)"
 USER_PATTERN = BASE_PATTERN + r"/" + USER
 
 
@@ -27,10 +26,8 @@ class SnapchatExtractor(Extractor):
 
     def _extract_next_data(self, url):
         html = self.request(url).text
-        data = text.extr(html,
-                         '<script id="__NEXT_DATA__" type="application/json">',
-                         '</script>')
-        return util.json_loads(data)["props"]["pageProps"]
+        data = self._extract_nextdata(html)
+        return data["props"]["pageProps"]
 
     def _extract_avatar(self, next_data):
         metadata = next_data["userProfile"]["publicProfileInfo"].copy()
@@ -167,7 +164,7 @@ class SnapchatStoryExtractor(SnapchatExtractor):
 class SnapchatSpotlightExtractor(SnapchatExtractor):
     """Extracts an individual spotlight post"""
     subcategory = "spotlight"
-    pattern = BASE_PATTERN + rf"/(?:{USER})?spotlight/{ALPHANUMERIC}"
+    pattern = BASE_PATTERN + rf"/(?:{USER})?spotlight/[^/?#]+"
     example = "https://www.snapchat.com/spotlight/" + \
         "W7_EDlXWTBiXAEEniNoMPwAAYdGFzb3FpYXVuAZqDMm6sAZqDMm6VAAAAAQ"
 

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -194,7 +194,6 @@ CATEGORY_MAP = {
     "slickpic"       : "SlickPic",
     "slideshare"     : "SlideShare",
     "smugmug"        : "SmugMug",
-    "snapchat"       : "Snapchat",
     "socialmediagirlsforum": "Social Media Girls Forums",
     "speakerdeck"    : "Speaker Deck",
     "steamgriddb"    : "SteamGridDB",

--- a/scripts/supportedsites.py
+++ b/scripts/supportedsites.py
@@ -194,6 +194,7 @@ CATEGORY_MAP = {
     "slickpic"       : "SlickPic",
     "slideshare"     : "SlideShare",
     "smugmug"        : "SmugMug",
+    "snapchat"       : "Snapchat",
     "socialmediagirlsforum": "Social Media Girls Forums",
     "speakerdeck"    : "Speaker Deck",
     "steamgriddb"    : "SteamGridDB",
@@ -442,6 +443,10 @@ SUBCATEGORY_MAP = {
     },
     "smugmug": {
         "path": "Images from Users and Folders",
+    },
+    "snapchat": {
+        "story": "",
+        "spotlight": "",
     },
     "steamgriddb": {
         "asset": "Individual Assets",

--- a/test/results/snapchat.py
+++ b/test/results/snapchat.py
@@ -4,7 +4,6 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
-from gallery_dl import exception
 from gallery_dl.extractor import snapchat
 
 BASE_DOMAIN_PATTERN = r"https://(?:cf-st|bolt-gcdn)"
@@ -26,7 +25,7 @@ __tests__ = (
     "#comment"  : "Avatar (Non-Existent)",
     "#category" : ("", "snapchat", "avatar"),
     "#class"    : snapchat.SnapchatAvatarExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 
 {
@@ -62,7 +61,7 @@ __tests__ = (
     "#comment"  : "Story/Highlight (Non-Existent)",
     "#category" : ("", "snapchat", "story"),
     "#class"    : snapchat.SnapchatStoryExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 
 {
@@ -90,7 +89,7 @@ __tests__ = (
     "#comment"  : "Spotlight (Non-Existent)",
     "#category" : ("", "snapchat", "spotlight"),
     "#class"    : snapchat.SnapchatSpotlightExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 
 {
@@ -116,7 +115,7 @@ __tests__ = (
     "#comment"  : "User Stories (Non-Existent)",
     "#category" : ("", "snapchat", "stories"),
     "#class"    : snapchat.SnapchatStoriesExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 
 {
@@ -133,7 +132,7 @@ __tests__ = (
     "#comment"  : "User Spotlights (Non-Existent)",
     "#category" : ("", "snapchat", "spotlights"),
     "#class"    : snapchat.SnapchatSpotlightsExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 
 {
@@ -160,6 +159,6 @@ __tests__ = (
     "#comment"  : "User (Non-Existent)",
     "#category" : ("", "snapchat", "user"),
     "#class"    : snapchat.SnapchatUserExtractor,
-    "#exception": exception.HttpError,
+    "#exception": "HttpError",
 },
 )

--- a/test/results/snapchat.py
+++ b/test/results/snapchat.py
@@ -139,7 +139,7 @@ __tests__ = (
 {
     "#url"      : "https://www.snapchat.com/@drkashmalahussa",
     "#comment"  : "User",
-    "#category" : ("", "snapchat", "users"),
+    "#category" : ("", "snapchat", "user"),
     "#class"    : snapchat.SnapchatUserExtractor,
     "#pattern"  : r"(?:" + AVATAR_PATTERN + r"|" + SNAP_PATTERN + r")",
     "#count"    : 18,
@@ -149,7 +149,7 @@ __tests__ = (
 {
     "#url"      : "https://www.snapchat.com/add/drkashmalahussa",
     "#comment"  : "User (/add/ Variant)",
-    "#category" : ("", "snapchat", "users"),
+    "#category" : ("", "snapchat", "user"),
     "#class"    : snapchat.SnapchatUserExtractor,
     "#pattern"  : r"(?:" + AVATAR_PATTERN + r"|" + SNAP_PATTERN + r")",
     "#count"    : 18,
@@ -158,7 +158,7 @@ __tests__ = (
 {
     "#url"      : "https://www.snapchat.com/@abc123123123123zzzzzzzgh",
     "#comment"  : "User (Non-Existent)",
-    "#category" : ("", "snapchat", "users"),
+    "#category" : ("", "snapchat", "user"),
     "#class"    : snapchat.SnapchatUserExtractor,
     "#exception": exception.HttpError,
 },

--- a/test/results/snapchat.py
+++ b/test/results/snapchat.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from gallery_dl import exception
+from gallery_dl.extractor import snapchat
+
+BASE_DOMAIN_PATTERN = r"https://(?:cf-st|bolt-gcdn)"
+AVATAR_PATTERN = BASE_DOMAIN_PATTERN + r".sc-cdn.net/(?:aps/bolt|3d/render)/[^/?#.]+\.[^/?#.]+"
+SNAP_PATTERN = BASE_DOMAIN_PATTERN + r".sc-cdn.net/[dju]/[^/?#]+\?mo=[^/?#.]+&uc=\d+"
+
+
+__tests__ = (
+{
+    "#url"      : "https://www.snapchat.com/@snackattackshow/avatar",
+    "#comment"  : "Avatar",
+    "#category" : ("", "snapchat", "avatar"),
+    "#class"    : snapchat.SnapchatAvatarExtractor,
+    "#pattern"  : AVATAR_PATTERN,
+    "user"      : "snackattackshow",
+},
+{
+    "#url"      : "https://www.snapchat.com/@idontexistabc123xyz/avatar",
+    "#comment"  : "Avatar (Non-Existent)",
+    "#category" : ("", "snapchat", "avatar"),
+    "#class"    : snapchat.SnapchatAvatarExtractor,
+    "#exception": exception.HttpError,
+},
+
+{
+    "#url"      : "https://www.snapchat.com/@snackattackshow/PnJFM8uuTRWo90OsrEH5pwAAgeGZvd2RrZGxxAZ1I2NonAZ1I2NmfAAAAAA",
+    "#comment"  : '"Timed" Story (difficult to test; if the user does not have a story with a purple-outline, this test will fail)',
+    "#category" : ("", "snapchat", "story"),
+    "#class"    : snapchat.SnapchatStoryExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "user"      : "snackattackshow",
+},
+{
+    "#url"      : "https://www.snapchat.com/@snackattackshow/highlight/c3050cba-2f43-4e06-8ac4-d79069bac22f",
+    "#comment"  : 'Story/Highlight (also difficult to test, as the website will only know about the latest stories)',
+    "#category" : ("", "snapchat", "story"),
+    "#class"    : snapchat.SnapchatStoryExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 1,
+    "id"        : "c3050cba-2f43-4e06-8ac4-d79069bac22f",
+    "user"      : "snackattackshow",
+},
+{
+    "#url"      : "https://www.snapchat.com/@snackattackshow/highlight/020d67db-8779-497c-ae95-06371c42c11d",
+    "#comment"  : 'Story/Highlight Multiple Items (also difficult to test, as the website will only know about the latest stories)',
+    "#category" : ("", "snapchat", "story"),
+    "#class"    : snapchat.SnapchatStoryExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 2,
+    "id"        : "020d67db-8779-497c-ae95-06371c42c11d",
+    "user"      : "snackattackshow",
+},
+{
+    "#url"      : "https://www.snapchat.com/@idontexistabc123xyz/highlight/020d67db-8779-497c-ae95-06371c42c11d",
+    "#comment"  : "Story/Highlight (Non-Existent)",
+    "#category" : ("", "snapchat", "story"),
+    "#class"    : snapchat.SnapchatStoryExtractor,
+    "#exception": exception.HttpError,
+},
+
+{
+    "#url"      : "https://www.snapchat.com/@manahil33922/spotlight/W7_EDlXWTBiXAEEniNoMPwAAYaGZnZm5tcXBsAZsRADeyAZsRADecAAAAAQ",
+    "#comment"  : "Spotlight (with Username)",
+    "#category" : ("", "snapchat", "spotlight"),
+    "#class"    : snapchat.SnapchatSpotlightExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 1,
+    "id"        : "W7_EDlXWTBiXAEEniNoMPwAAYaGZnZm5tcXBsAZsRADeyAZsRADecAAAAAQ",
+    "user"      : "manahil33922",
+},
+{
+    "#url"      : "https://www.snapchat.com/spotlight/W7_EDlXWTBiXAEEniNoMPwAAYaGZnZm5tcXBsAZsRADeyAZsRADecAAAAAQ",
+    "#comment"  : "Spotlight (without Username)",
+    "#category" : ("", "snapchat", "spotlight"),
+    "#class"    : snapchat.SnapchatSpotlightExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 1,
+    "id"        : "W7_EDlXWTBiXAEEniNoMPwAAYaGZnZm5tcXBsAZsRADeyAZsRADecAAAAAQ",
+    "user"      : "manahil33922",
+},
+{
+    "#url"      : "https://www.snapchat.com/spotlight/W7_EDlXWTBiXAEEniNoMPwAAYaGZnZm5tcAAQ",
+    "#comment"  : "Spotlight (Non-Existent)",
+    "#category" : ("", "snapchat", "spotlight"),
+    "#class"    : snapchat.SnapchatSpotlightExtractor,
+    "#exception": exception.HttpError,
+},
+
+{
+    "#url"      : "https://www.snapchat.com/@drkashmalahussa/stories",
+    "#comment"  : "User Stories",
+    "#category" : ("", "snapchat", "stories"),
+    "#class"    : snapchat.SnapchatStoriesExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 4,
+    "user"      : "drkashmalahussa",
+},
+{
+    "#url"      : "https://www.snapchat.com/@drkashmalahussa/highlights",
+    "#comment"  : "User Highlights",
+    "#category" : ("", "snapchat", "stories"),
+    "#class"    : snapchat.SnapchatStoriesExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 4,
+    "user"      : "drkashmalahussa",
+},
+{
+    "#url"      : "https://www.snapchat.com/@abc123123123123zzzzzzzgh/stories",
+    "#comment"  : "User Stories (Non-Existent)",
+    "#category" : ("", "snapchat", "stories"),
+    "#class"    : snapchat.SnapchatStoriesExtractor,
+    "#exception": exception.HttpError,
+},
+
+{
+    "#url"      : "https://www.snapchat.com/@drkashmalahussa/spotlights",
+    "#comment"  : "User Spotlights",
+    "#category" : ("", "snapchat", "spotlights"),
+    "#class"    : snapchat.SnapchatSpotlightsExtractor,
+    "#pattern"  : SNAP_PATTERN,
+    "#count"    : 13,
+    "user"      : "drkashmalahussa",
+},
+{
+    "#url"      : "https://www.snapchat.com/@abc123123123123zzzzzzzgh/spotlights",
+    "#comment"  : "User Spotlights (Non-Existent)",
+    "#category" : ("", "snapchat", "spotlights"),
+    "#class"    : snapchat.SnapchatSpotlightsExtractor,
+    "#exception": exception.HttpError,
+},
+
+{
+    "#url"      : "https://www.snapchat.com/@drkashmalahussa",
+    "#comment"  : "User",
+    "#category" : ("", "snapchat", "users"),
+    "#class"    : snapchat.SnapchatUserExtractor,
+    "#pattern"  : r"(?:" + AVATAR_PATTERN + r"|" + SNAP_PATTERN + r")",
+    "#count"    : 18,
+    "user"      : "drkashmalahussa",
+},
+
+{
+    "#url"      : "https://www.snapchat.com/add/drkashmalahussa",
+    "#comment"  : "User (/add/ Variant)",
+    "#category" : ("", "snapchat", "users"),
+    "#class"    : snapchat.SnapchatUserExtractor,
+    "#pattern"  : r"(?:" + AVATAR_PATTERN + r"|" + SNAP_PATTERN + r")",
+    "#count"    : 18,
+    "user"      : "drkashmalahussa",
+},
+{
+    "#url"      : "https://www.snapchat.com/@abc123123123123zzzzzzzgh",
+    "#comment"  : "User (Non-Existent)",
+    "#category" : ("", "snapchat", "users"),
+    "#class"    : snapchat.SnapchatUserExtractor,
+    "#exception": exception.HttpError,
+},
+)


### PR DESCRIPTION
This PR adds support for Snapchat stories/highlights, spotlight [posts], and user avatars. The new extractor also supports downloading "timed" stories? I have no idea what they are called, they show up on a user's feed with a purple outline, and then disappear after a while.

Some important limitations that need documenting, as I am sure users will create issues for these:

1. It seems like [the website](https://www.snapchat.com/) does not let you retrieve every highlight and spotlight that a user has posted. Only twenty or so posts will be rendered, and scrolling down the page does not load any more posts. I've checked the Networking tab and the page does not appear to make any [pertinent] API calls at all, so either endpoints to grab more posts don't exist, or we don't know what they are [yet].
    - It is worth noting, though, that the mobile app _will_ allow you to see more stories and spotlights. This would be my next avenue of investigation, but I don't have the time nor patience to carry out such investigative work. I don't really use Snapchat to begin with.
    - ~A workaround could be to extract individual stories and spotlights, but this requires that you know the story's/spotlight's ID. I haven't tried figuring out how to get this information from mobile yet, though I suspect you could share the story or spotlight from mobile to desktop and obtain it that way?~
       - I have tried this, I was able to get a spotlight's ID via sharing it from my mobile application, but when I tried accessing the spotlight from the web, it 404ed. So it seems like some content is not available for web for whatever reason.
2. I can only find URLs to really low quality avatars in the JSON data, unfortunately. Something is better than nothing, I guess.
3. I can't find a way to remove the Snapchat watermark. Snapchat doesn't appear to serve watermark-less alternatives like TikTok does.

Closes: #7126.