### PR TITLE
[deviantart] handle missing 'src' in deviation_download response

### DIFF
--- a/gallery_dl/extractor/deviantart.py
+++ b/gallery_dl/extractor/deviantart.py
@@ -195,8 +195,15 @@ class DeviantartExtractor(Extractor):
 
             elif self.original and deviation["is_downloadable"]:
                 content = self.api.deviation_download(deviation["deviationid"])
-                deviation["is_original"] = True
-                yield self.commit(deviation, content)
+                if "src" not in content:
+                    self.log.warning(
+                        "%s: Unable to get download URL for '%s'",
+                        deviation["index"],
+                        deviation.get("title") or deviation["deviationid"],
+                    )
+                else:
+                    deviation["is_original"] = True
+                    yield self.commit(deviation, content)
 
             if "videos" in deviation and deviation["videos"]:
                 video = max(deviation["videos"],


### PR DESCRIPTION
The deviation_download API can return a response without a "src" field
when the download limit is hit or when content is subscriber-only.
This causes a KeyError crash in commit().

Instead of crashing, log a warning and skip the download attempt.
If the deviation has a video counterpart, it will still be picked up
by the videos block below.

Fixes #9307
Related: #9072