### PR TITLE
[webtoons] add date metadata to comic episode listings

### DIFF
--- a/gallery_dl/extractor/webtoons.py
+++ b/gallery_dl/extractor/webtoons.py
@@ -10,7 +10,7 @@
 """Extractors for https://www.webtoons.com/"""
 
 from .common import GalleryExtractor, Extractor, Message
-from .. import text, util
+from .. import dt, text, util
 
 BASE_PATTERN = r"(?:https?://)?(?:www\.)?webtoons\.com"
 LANG_PATTERN = BASE_PATTERN + r"/(([^/?#]+)"
@@ -233,9 +233,10 @@ class WebtoonsComicExtractor(WebtoonsBase, Extractor):
 
         data = {"_extractor": WebtoonsEpisodeExtractor}
         while True:
-            for url in self.get_episode_urls(page):
+            for url, date in self.get_episode_urls(page):
                 params = text.parse_query(url.rpartition("?")[2])
                 data["episode_no"] = text.parse_int(params.get("episode_no"))
+                data["date"] = _parse_date(date, kw["lang"])
                 yield Message.Queue, url, data
 
             kw["page"] = page_no = page_no + 1
@@ -245,12 +246,14 @@ class WebtoonsComicExtractor(WebtoonsBase, Extractor):
             page = self.request(self.root + path).text
 
     def get_episode_urls(self, page):
-        """Extract and return all episode urls in 'page'"""
+        """Extract and return all episode urls and dates in 'page'"""
         page = text.extr(page, 'id="_listUl"', "</ul>")
-        return [
+        urls = [
             match[0]
             for match in WebtoonsEpisodeExtractor.pattern.finditer(page)
         ]
+        dates = list(text.extract_iter(page, 'class="date">', '<'))
+        return list(zip(urls, dates))
 
     def _asset_banner(self, page):
         try:
@@ -297,3 +300,39 @@ class WebtoonsArtistExtractor(WebtoonsBase, Extractor):
 
 def _url(url):
     return url.replace("://webtoon-phinf.", "://swebtoon-phinf.")
+
+
+_MONTHS = {lang: {m: i for i, m in enumerate(months, 1)} for lang, months in {
+    "fr": ["janv", "févr", "mars", "avr", "mai", "juin",
+           "juil", "août", "sept", "oct", "nov", "déc"],
+    "es": ["ene", "feb", "mar", "abr", "may", "jun",
+           "jul", "ago", "sept", "oct", "nov", "dic"],
+    "th": ["มค", "กพ", "มีค", "เมย", "พค", "มิย",
+           "กค", "สค", "กย", "ตค", "พย", "ธค"],
+}.items()}
+
+
+def _parse_date(date_string, lang):
+    """Parse a locale-dependent date string from the episode list"""
+    try:
+        date_string = date_string.strip()
+
+        if lang == "en":
+            return dt.parse(date_string, "%b %d, %Y")
+        if lang == "de":
+            return dt.parse(date_string, "%d.%m.%Y")
+        if lang == "id":
+            return dt.parse(date_string, "%d %b %Y")
+        if lang == "zh-hant":
+            year, month, day = date_string.replace(
+                "年", " ").replace("月", " ").replace("日", "").split()
+            return dt.datetime(int(year), int(month), int(day))
+
+        # fr, es, th: "DD month_abbr YYYY"
+        months = _MONTHS.get(lang)
+        if not months:
+            return dt.NONE
+        day, month, year = date_string.replace(".", "").split()
+        return dt.datetime(int(year), months[month.lower()], int(day))
+    except Exception:
+        return dt.NONE

--- a/test/results/webtoons.py
+++ b/test/results/webtoons.py
@@ -190,6 +190,91 @@ __tests__ = (
     "page"      : range(1, 2),
     "title_no"  : 919,
     "episode_no": range(1, 14),
+    "date"      : "type:datetime",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/en/comedy/live-with-yourself/list?title_no=919",
+    "#comment" : "episode date, english",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "14",
+    "#count"   : 1,
+
+    "title_no"  : 919,
+    "episode_no": 1,
+    "date"      : "dt:2017-01-01 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/fr/romance/subzero/list?title_no=1845&page=24",
+    "#comment" : "episode date, french",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "6",
+    "#count"   : 1,
+
+    "title_no"  : 1845,
+    "episode_no": 1,
+    "date"      : "dt:2019-12-19 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/es/romance/lore-olympus/list?title_no=1725",
+    "#comment" : "episode date, spanish",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "9",
+    "#count"   : 1,
+
+    "title_no"  : 1725,
+    "episode_no": 1,
+    "date"      : "dt:2019-11-21 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/de/fantasy/werewolves-going-crazy-over-me/list?title_no=8127&page=5",
+    "#comment" : "episode date, german",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "9",
+    "#count"   : 1,
+
+    "title_no"  : 8127,
+    "episode_no": 1,
+    "date"      : "dt:2025-05-17 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/id/romance/daytime-in-the-bunker/list?title_no=9889",
+    "#comment" : "episode date, indonesian",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "3",
+    "#count"   : 1,
+
+    "title_no"  : 9889,
+    "episode_no": 1,
+    "date"      : "dt:2026-04-07 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/zh-hant/school/kanlianshidai/list?title_no=546&page=60",
+    "#comment" : "episode date, chinese traditional",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "5",
+    "#count"   : 1,
+
+    "title_no"  : 546,
+    "episode_no": 1,
+    "date"      : "dt:2015-09-30 00:00:00",
+},
+
+{
+    "#url"     : "https://www.webtoons.com/th/action/lookism/list?title_no=576&page=60",
+    "#comment" : "episode date, thai",
+    "#class"   : webtoons.WebtoonsComicExtractor,
+    "#range"   : "7",
+    "#count"   : 1,
+
+    "title_no"  : 576,
+    "episode_no": 1,
+    "date"      : "dt:2015-11-04 00:00:00",
 },
 
 {
@@ -209,6 +294,7 @@ __tests__ = (
     "?type"      : "banner",
     "title_no"   : 919,
     "?episode_no": range(12, 14),
+    "?date"      : "type:datetime",
 },
 
 {
@@ -221,6 +307,7 @@ __tests__ = (
     "page"      : range(7, 25),
     "title_no"  : 1845,
     "episode_no": int,
+    "date"      : "type:datetime",
 },
 
 {
@@ -233,6 +320,7 @@ __tests__ = (
     "page"      : int,
     "title_no"  : 210827,
     "episode_no": int,
+    "date"      : "type:datetime",
 },
 
 {


### PR DESCRIPTION
Parse the date from each episode's listing on the comic page and
include it in the metadata passed to the episode extractor.

Supports all 7 webtoons locales:
- en, de, id: strptime with locale-appropriate format strings
- zh-hant: split on CJK date characters
- fr, es, th: per-language month abbreviation lookups

Unknown locales fall back to `dt.NONE`.

Test cases with exact date assertions are included for each locale,
pinned to the oldest episode of completed or stable comics.